### PR TITLE
Add initial configuration for aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build-iPhoneSimulator/
 # .rubocop-https?--*
 
 .idea
+.rspec_status

--- a/.rspec_status
+++ b/.rspec_status
@@ -1,4 +1,0 @@
-example_id                         | status | run_time        |
----------------------------------- | ------ | --------------- |
-./spec/pipefy_message_spec.rb[1:1] | passed | 0.00092 seconds |
-./spec/pipefy_message_spec.rb[1:2] | passed | 0.00082 seconds |

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,12 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in pipefy_message.gemspec
 gemspec
 
+gem "aws-sdk-sns", "~> 1.50.0"
 gem "rake", "~> 13.0"
 
-gem "rspec", "~> 3.0"
-
-gem "rubocop", "~> 1.21"
-
-gem 'aws-sdk-sns', '~> 1.50.0'
-
+group :development, :test do
+  gem "pry"
+  gem "pry-doc"
+  gem "rspec", "~> 3.0"
+  gem "rubocop", "~> 1.21"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,6 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
+
+gem 'aws-sdk-sns', '~> 1.50.0'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,11 +19,19 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    coderay (1.1.3)
     diff-lcs (1.3)
     jmespath (1.5.0)
+    method_source (1.0.0)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-doc (1.3.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.1.1)
@@ -54,6 +62,9 @@ GEM
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.1.0)
+    webrick (1.7.0)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
 
 PLATFORMS
   x86_64-darwin-20
@@ -62,9 +73,11 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-sns (~> 1.50.0)
   pipefy_message!
+  pry
+  pry-doc
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
 
 BUNDLED WITH
-   2.2.29
+   2.3.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.549.0)
+    aws-sdk-core (3.125.5)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-sns (1.50.0)
+      aws-sdk-core (~> 3, >= 3.125.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.4.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.3)
+    jmespath (1.5.0)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -47,6 +60,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-sns (~> 1.50.0)
   pipefy_message!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/lib/pipefy_message.rb
+++ b/lib/pipefy_message.rb
@@ -2,14 +2,17 @@
 
 require_relative "pipefy_message/version"
 require_relative "pipefy_message/configuration"
+require "pry"
 
 module PipefyMessage
   # Simple Test class to validate the project
   class Test
-
     def hello
+      connection = PipefyMessage::AwsProviderConfig.instance
+
       sns = Aws::SNS::Resource.new
 
+      puts connection.do_connection
       puts sns.topics
       puts "It's Alive !"
     end

--- a/lib/pipefy_message.rb
+++ b/lib/pipefy_message.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
 require_relative "pipefy_message/version"
+require_relative "pipefy_message/configuration"
 
 module PipefyMessage
   # Simple Test class to validate the project
   class Test
+
     def hello
+      sns = Aws::SNS::Resource.new
+
+      puts sns.topics
       puts "It's Alive !"
     end
   end

--- a/lib/pipefy_message/configuration.rb
+++ b/lib/pipefy_message/configuration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "aws-sdk-sns"
+
+module PipefyMessage
+  # Aws Provider Config class to connect with the cloud resources
+  class AwsProviderConfig
+    def self.do_connection
+      Aws.config.update(
+        endpoint: ENV["AWS_ENDPOINT"],
+        access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+        secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+        region: ENV["AWS_REGION"] || "us-east-1"
+      )
+    end
+  end
+
+end
+

--- a/lib/pipefy_message/configuration.rb
+++ b/lib/pipefy_message/configuration.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require "aws-sdk-sns"
+require "singleton"
 
 module PipefyMessage
   # Aws Provider Config class to connect with the cloud resources
   class AwsProviderConfig
-    def self.do_connection
+    include Singleton
+
+    def do_connection
       Aws.config.update(
         endpoint: ENV["AWS_ENDPOINT"],
         access_key_id: ENV["AWS_ACCESS_KEY_ID"],
@@ -14,6 +17,4 @@ module PipefyMessage
       )
     end
   end
-
 end
-

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe PipefyMessage::AwsProviderConfig do
+  context "when I try to connect with AWS provider" do
+    it "should return a hash with correct values" do
+      keys = PipefyMessage::AwsProviderConfig.instance.do_connection
+
+      expected = { endpoint: ENV["AWS_ENDPOINT"], access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+                   secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"], region: "us-east-1" }
+
+      expect(keys).to eq expected
+    end
+
+    it "should return a Singleton" do
+      first_instance = PipefyMessage::AwsProviderConfig.instance
+      second_instance = PipefyMessage::AwsProviderConfig.instance
+
+      expect(first_instance).to eq(second_instance)
+    end
+  end
+end


### PR DESCRIPTION
# ✨ New Feature

This MR creates a connection singleton with AWS.

# :repeat: Steps to reproduce

```
export AWS_ENDPOINT=foo
export AWS_ACCESS_KEY_ID=bar
export AWS_SECRET_ACCESS_KEY=aws

sudo bundle install
sudo gem build pipefy_message.gemspec
sudo gem install pipefy_message-0.1.0.gem

irb

require 'pipefy_message'
message = PipefyMessage::Test.new
message.hello
```

# 🗂 Related cards

[[async] Create SNS setup inside the gem](https://app.pipefy.com/open-cards/490986945)
