### PR TITLE
Create SNS Producer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+
+build-app-infra:
+	@docker-compose up -d
+	@echo "Checking if the localstack SNS and SQS resources are created"
+	@sleep 10
+	docker logs aws-cli;
+
+recreate-app-infra: delete-app-infra build-app-infra
+
+delete-app-infra:
+	@docker-compose down -v --remove-orphans
+
+build-app:
+	bundle install
+	gem build pipefy_message.gemspec
+	gem install pipefy_message-[0-9].[0-9].[0-9].gem

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 build-app-infra:
 	@docker-compose up -d
 	@echo "Checking if the localstack SNS and SQS resources are created"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Or install it yourself as:
 To test changes without install this dependency on your application, on the project root execute:
 
     $ make build-app
+    $ make build-app-infra
+
+If you need to recreate the infra (SNS and SQS) run:
+
+    $ make recreate-app-infra
 
 After that, we are going to test the gem with these commands:
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ Or install it yourself as:
 
 To test changes without install this dependency on your application, on the project root execute:
 
-    $ bundle install
-    $ gem build pipefy_message.gemspec
-    $ gem install pipefy_message-0.1.0.gem
+    $ make build-app
 
 After that, we are going to test the gem with these commands:
 
@@ -45,8 +43,23 @@ On the irb console:
     $ message = PipefyMessage::Test.new
     $ message.hello
 
+## Project Stack
+
+- [Aws SDK Ruby - SNS & SQS](https://github.com/aws/aws-sdk-ruby)
+- [Bundler](https://bundler.io/)
+- Docker-compose
+- [GitHub Actions](https://docs.github.com/en/actions)
+- Makefile
+- Ruby 2.6.6
+- [Rubocop](https://github.com/rubocop/rubocop)
+
+## Brokers Documentation
+
+* [SNS & SQS User guide](https://github.com/pipefy/pipefy_message/tree/main/lib/pipefy_message/broker/aws/README.md)
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/pipefy/pipefy_message.
 
 > Follow the [template](https://github.com/pipefy/pipefy_message/blob/main/.github/pull_request_template.md) while opening a PR
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
 
@@ -6,11 +6,11 @@ services:
     container_name: localstack
     image: localstack/localstack-light:0.11.5
     environment:
+      AWS_DEFAULT_REGION: us-east-1
       LOCALSTACK_SERVICES: sns,sqs
       DEFAULT_REGION: us-east-1
-      AWS_DEFAULT_REGION: us-east-1
     ports:
-      - 4576:4576
+      - 4566:4566
       - 4571:4571
 
   aws-cli:
@@ -34,6 +34,8 @@ services:
 
         # Creating Subscription from SQS to SNS
         aws --endpoint-url=http://localstack:4566 sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:pipefy-local-topic --protocol sqs --notification-endpoint http://localstack:4566/000000000000/pipefy-local-queue
+
+        aws --endpoint-url=http://localstack:4566 sqs receive-message --queue-url http://localstack:4566/000000000000/pipefy-local-queue
       "
     depends_on:
           - localstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+services:
+
+  localstack:
+    container_name: localstack
+    image: localstack/localstack-light:0.11.5
+    environment:
+      LOCALSTACK_SERVICES: sns,sqs
+      DEFAULT_REGION: us-east-1
+      AWS_DEFAULT_REGION: us-east-1
+    ports:
+      - 4576:4576
+      - 4571:4571
+
+  aws-cli:
+    container_name: aws-cli
+    image: amazon/aws-cli:latest
+    environment:
+      AWS_ACCESS_KEY_ID: DEV123
+      AWS_SECRET_ACCESS_KEY: DEV123
+      AWS_DEFAULT_REGION: us-east-1
+    entrypoint: /bin/sh -c
+    command: >
+      "
+        # Wait for localstack boot
+        sleep 10
+
+        # Creating SNS Topics
+        aws --endpoint-url=http://localstack:4566 sns create-topic --name pipefy-local-topic
+
+        # Creating SQS Queues
+        aws --endpoint-url=http://localstack:4566 sqs create-queue --queue-name pipefy-local-queue
+
+        # Creating Subscription from SQS to SNS
+        aws --endpoint-url=http://localstack:4566 sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:pipefy-local-topic --protocol sqs --notification-endpoint http://localstack:4566/000000000000/pipefy-local-queue
+      "
+    depends_on:
+          - localstack

--- a/lib/pipefy_message.rb
+++ b/lib/pipefy_message.rb
@@ -2,18 +2,20 @@
 
 require_relative "pipefy_message/version"
 require_relative "pipefy_message/configuration"
+require_relative "pipefy_message/broker/aws/sns/publisher"
 require "pry"
 
 module PipefyMessage
   # Simple Test class to validate the project
   class Test
     def hello
-      connection = PipefyMessage::AwsProviderConfig.instance
 
-      sns = Aws::SNS::Resource.new
 
-      puts connection.do_connection
-      puts sns.topics
+      publisher = SnsPublisher.new
+
+      payload = { foo: "bar" }
+
+      puts publisher.publish(payload, "arn:aws:sns:us-east-1:000000000000:pipefy-local-topic")
       puts "It's Alive !"
     end
   end

--- a/lib/pipefy_message.rb
+++ b/lib/pipefy_message.rb
@@ -9,8 +9,6 @@ module PipefyMessage
   # Simple Test class to validate the project
   class Test
     def hello
-
-
       publisher = SnsPublisher.new
 
       payload = { foo: "bar" }

--- a/lib/pipefy_message/broker/aws/README.md
+++ b/lib/pipefy_message/broker/aws/README.md
@@ -1,0 +1,63 @@
+# AWS SNS & SQS User Guide
+
+## Basics
+
+**SNS**: Amazon Simple Notification Service (SNS) is a fully managed pub/sub messaging, SMS, email, and mobile push notifications. More details at the [official website](https://aws.amazon.com/sns/).
+
+**SQS**: Amazon Simple Queue Service (SQS) is a fully managed message queuing service that enables you to decouple and scale microservices, distributed systems, and serverless applications. More details at the [official website](https://aws.amazon.com/sqs/).
+
+### Aws-cli Installation
+
+Before proceed to the next step it's required to have the aws-cli installed in your machine, for that follow [this guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+
+> **Note that we must have the project docker-compose localstack service running before executing the commands above**
+### Creating new SNS Topic
+
+On your terminal run:
+
+```bash
+aws --endpoint-url=http://localhost:4566 sns create-topic --name pipe-events-topic
+```
+The expected output is:
+```bash
+{
+  "TopicArn": "arn:aws:sns:us-east-1:000000000000:pipe-events-topic"
+}
+```
+
+Parameters:
+* **name** is the final topic name that will be used at localstack (can be changed for any name).
+
+### Creating new SQS Queue
+
+On your terminal run:
+
+```bash
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name pipe-events-queue
+```
+The expected output is:
+```bash
+{
+  "QueueUrl": "http://localhost:4566/000000000000/pipe-events-queue"
+}
+```
+
+Parameters:
+* **queue-name** is the final queue name that will be used at localstack (can be changed for any name).
+
+### Creating a new Subscription from SQS to SNS topic
+
+On your terminal run:
+
+```bash
+aws --endpoint-url=http://localhost:4566 sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:pipe-events-topic --protocol sqs --notification-endpoint http://localhost:4566/000000000000/pipe-events-queue
+```
+The expected output is:
+```bash
+{
+  "QueueUrl": "http://localhost:4566/000000000000/pipe-events-queue"
+}
+```
+Parameters:
+* **topic-arn** is the output of the topic creation.
+* **notification-endpoint** is the output of the queue creation.

--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -6,15 +6,13 @@ require "json"
 module PipefyMessage
   # Aws SNS Publisher class to publish json messages into a specific topic
   class SnsPublisher
-
     def initialize
-      awsConfig = PipefyMessage::AwsProviderConfig.instance
-      awsConfig.setup_connection
+      aws_config = PipefyMessage::AwsProviderConfig.instance
+      aws_config.setup_connection
       @sns = Aws::SNS::Resource.new
     end
 
     def publish(payload, topic_arn)
-
       message = prepare_payload(payload)
       do_publish(message, topic_arn)
     end
@@ -35,11 +33,8 @@ module PipefyMessage
       topic.publish({
                       message: message.to_json,
                       message_structure: "json"
-                    }
-      )
+                    })
       puts "Message Published with ID #{result.message_id}"
     end
-
   end
 end
-

--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "aws-sdk-sns"
+require "json"
+
+module PipefyMessage
+  # Aws SNS Publisher class to publish json messages into a specific topic
+  class SnsPublisher
+
+    def initialize
+      awsConfig = PipefyMessage::AwsProviderConfig.instance
+      awsConfig.setup_connection
+      @sns = Aws::SNS::Resource.new
+    end
+
+    def publish(payload, topic_arn)
+
+      topic = @sns.topic(topic_arn)
+
+      puts "Publishing a json message to topic #{topic_arn}"
+
+      # The 'Default' json key/entry it's mandatory to ruby sdk
+      message = {
+        "default" => payload
+      }
+
+      result = topic.publish({
+                               message: message.to_json,
+                               message_structure: "json"
+                             }
+      )
+
+      puts "Message Published with ID #{result.message_id}"
+    end
+
+  end
+end
+

--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -7,8 +7,7 @@ module PipefyMessage
   # Aws SNS Publisher class to publish json messages into a specific topic
   class SnsPublisher
     def initialize
-      aws_config = PipefyMessage::AwsProviderConfig.instance
-      aws_config.setup_connection
+      PipefyMessage::AwsProviderConfig.instance.setup_connection
       @sns = Aws::SNS::Resource.new
     end
 

--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -15,21 +15,28 @@ module PipefyMessage
 
     def publish(payload, topic_arn)
 
+      message = prepare_payload(payload)
+      do_publish(message, topic_arn)
+    end
+
+    private
+
+    def prepare_payload(payload)
+      # The 'Default' json key/entry it's mandatory to ruby sdk
+      {
+        "default" => payload
+      }
+    end
+
+    def do_publish(message, topic_arn)
       topic = @sns.topic(topic_arn)
 
       puts "Publishing a json message to topic #{topic_arn}"
-
-      # The 'Default' json key/entry it's mandatory to ruby sdk
-      message = {
-        "default" => payload
-      }
-
-      result = topic.publish({
-                               message: message.to_json,
-                               message_structure: "json"
-                             }
+      topic.publish({
+                      message: message.to_json,
+                      message_structure: "json"
+                    }
       )
-
       puts "Message Published with ID #{result.message_id}"
     end
 

--- a/lib/pipefy_message/configuration.rb
+++ b/lib/pipefy_message/configuration.rb
@@ -8,7 +8,7 @@ module PipefyMessage
   class AwsProviderConfig
     include Singleton
 
-    def do_connection
+    def setup_connection
       Aws.config.update(
         endpoint: ENV["AWS_ENDPOINT"],
         access_key_id: ENV["AWS_ACCESS_KEY_ID"],

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe PipefyMessage::AwsProviderConfig do
   context "when I try to connect with AWS provider" do
     it "should return a hash with correct values" do
-      keys = PipefyMessage::AwsProviderConfig.instance.do_connection
+      keys = PipefyMessage::AwsProviderConfig.instance.setup_connection
 
       expected = { endpoint: ENV["AWS_ENDPOINT"], access_key_id: ENV["AWS_ACCESS_KEY_ID"],
                    secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"], region: "us-east-1" }

--- a/spec/sns_publisher_spec.rb
+++ b/spec/sns_publisher_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe PipefyMessage::SnsPublisher do
+  context "when I try to publish a message with Sns publisher" do
+    before(:each) do
+      ENV["AWS_ENDPOINT"] = "http://localhost:4566"
+      ENV["AWS_ACCESS_KEY_ID"] = "foo"
+      ENV["AWS_SECRET_ACCESS_KEY"] = "bar"
+
+      @publisher = PipefyMessage::SnsPublisher.new
+    end
+    it "should return a message ID" do
+
+      mocked_return = { message_id: "5482c8be-db2c-44ec-a899-3aa52e424cc3",
+                        sequence_number: nil }
+
+      allow(@publisher).to receive(:do_publish).and_return(mocked_return)
+
+
+      payload = { foo: "bar" }
+      result = @publisher.publish(payload, "arn:aws:sns:us-east-1:000000000000:pipefy-local-topic")
+      expect(result).to eq mocked_return
+    end
+    it "should prepare the payload" do
+
+      payload = { foo: "bar", bar: "foo" }
+      prepared_payload = @publisher.send(:prepare_payload, payload)
+
+      expected_payload = { "default" => { bar: "foo", foo: "bar" } }
+
+      expect(prepared_payload).to eq(expected_payload)
+    end
+  end
+end

--- a/spec/sns_publisher_spec.rb
+++ b/spec/sns_publisher_spec.rb
@@ -10,19 +10,16 @@ RSpec.describe PipefyMessage::SnsPublisher do
       @publisher = PipefyMessage::SnsPublisher.new
     end
     it "should return a message ID" do
-
       mocked_return = { message_id: "5482c8be-db2c-44ec-a899-3aa52e424cc3",
                         sequence_number: nil }
 
       allow(@publisher).to receive(:do_publish).and_return(mocked_return)
-
 
       payload = { foo: "bar" }
       result = @publisher.publish(payload, "arn:aws:sns:us-east-1:000000000000:pipefy-local-topic")
       expect(result).to eq mocked_return
     end
     it "should prepare the payload" do
-
       payload = { foo: "bar", bar: "foo" }
       prepared_payload = @publisher.send(:prepare_payload, payload)
 


### PR DESCRIPTION
# ✨ New Feature

This MR contains the inclusion of SNS producer and a docker-compose file that provides localstack and aws-cli as services to create all infra stuff to simulate the usage of SNS and so on.

# :repeat: Steps to reproduce

Run the following commands at the project root, on your terminal:

```

make build-app
make build-app-infra

export AWS_ENDPOINT="http://localhost:4566"
export AWS_ACCESS_KEY_ID=foo
export AWS_SECRET_ACCESS_KEY=bar

irb

require 'pipefy_message'
message = PipefyMessage::Test.new
message.hello
```


# 🗂 Related cards

[[async] Create SNS producer inside the gem](https://app.pipefy.com/open-cards/490520520)
