### PR TITLE
SQS consumer Integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "aws-sdk-sns", "~> 1.50.0"
+gem "aws-sdk-sqs", "~> 1.49.0"
 gem "rake", "~> 13.0"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pipefy_message (0.1.0)
+    pipefy_message (1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -15,6 +15,9 @@ GEM
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
     aws-sdk-sns (1.50.0)
+      aws-sdk-core (~> 3, >= 3.125.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sqs (1.49.0)
       aws-sdk-core (~> 3, >= 3.125.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
@@ -72,6 +75,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-sns (~> 1.50.0)
+  aws-sdk-sqs (~> 1.49.0)
   pipefy_message!
   pry
   pry-doc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 build-app-infra:
 	@docker-compose up -d
 	@echo "Checking if the localstack SNS and SQS resources are created"

--- a/lib/pipefy_message.rb
+++ b/lib/pipefy_message.rb
@@ -3,18 +3,28 @@
 require_relative "pipefy_message/version"
 require_relative "pipefy_message/configuration"
 require_relative "pipefy_message/broker/aws/sns/publisher"
+require_relative "pipefy_message/base_consumer"
 require "pry"
 
 module PipefyMessage
   # Simple Test class to validate the project
   class Test
-    def hello
+    def publish
       publisher = SnsPublisher.new
-
       payload = { foo: "bar" }
-
       puts publisher.publish(payload, "arn:aws:sns:us-east-1:000000000000:pipefy-local-topic")
-      puts "It's Alive !"
+    end
+
+    def consume
+      puts "Starting the consumer process"
+      consumer = BaseConsumer.new("http://localhost:4566/000000000000/pipefy-local-queue")
+      puts "Creating new instance of consumer #{consumer}"
+      consumer.receive_message
+    end
+
+    def publish_and_consume
+      publish
+      consume
     end
   end
 end

--- a/lib/pipefy_message/base_consumer.rb
+++ b/lib/pipefy_message/base_consumer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "aws-sdk-sqs"
+require_relative "broker/aws/sqs/consumer"
+
+module PipefyMessage
+  # Aws SNS Publisher class to publish json messages into a specific topic
+  class BaseConsumer < SqsConsumer
+
+    def process_message(message)
+      puts "Processing Message"
+      puts "Message body: #{message}"
+    end
+  end
+end
+

--- a/lib/pipefy_message/base_consumer.rb
+++ b/lib/pipefy_message/base_consumer.rb
@@ -6,11 +6,10 @@ require_relative "broker/aws/sqs/consumer"
 module PipefyMessage
   # Aws SNS Publisher class to publish json messages into a specific topic
   class BaseConsumer < SqsConsumer
-
     def process_message(message)
       puts "Processing Message"
       puts "Message body: #{message}"
+      message
     end
   end
 end
-

--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -7,8 +7,7 @@ module PipefyMessage
   # Aws SNS Publisher class to publish json messages into a specific topic
   class SnsPublisher
     def initialize
-      aws_config = PipefyMessage::AwsProviderConfig.instance
-      aws_config.setup_connection
+      PipefyMessage::AwsProviderConfig.instance.setup_connection
       @sns = Aws::SNS::Resource.new
     end
 
@@ -30,10 +29,10 @@ module PipefyMessage
       topic = @sns.topic(topic_arn)
 
       puts "Publishing a json message to topic #{topic_arn}"
-      topic.publish({
-                      message: message.to_json,
-                      message_structure: "json"
-                    })
+      result = topic.publish({
+                               message: message.to_json,
+                               message_structure: "json"
+                             })
       puts "Message Published with ID #{result.message_id}"
     end
   end

--- a/lib/pipefy_message/broker/aws/sqs/consumer.rb
+++ b/lib/pipefy_message/broker/aws/sqs/consumer.rb
@@ -12,8 +12,7 @@ module PipefyMessage
       @poller = Aws::SQS::QueuePoller.new(queue_url)
     end
 
-    def receive_message
-
+    def consume_message
       @poller.poll(wait_time_seconds: 10) do |received_message|
         puts "Receiving Message from Broker"
         puts "Message ID:   #{received_message.message_id}"
@@ -21,12 +20,14 @@ module PipefyMessage
 
         process_message(payload["Message"])
 
+      rescue StandardError
+        puts "Failed to process message with ID: #{received_message.message_id}"
+        throw :skip_delete
       end
     end
 
-    def process_message(message)
+    def process_message(_message)
       raise "Must be implemented by a worker class"
     end
   end
 end
-

--- a/lib/pipefy_message/broker/aws/sqs/consumer.rb
+++ b/lib/pipefy_message/broker/aws/sqs/consumer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "aws-sdk-sqs"
+require "json"
+
+module PipefyMessage
+  # Aws SNS Publisher class to publish json messages into a specific topic
+  class SqsConsumer
+    def initialize(queue_url)
+      aws_config = PipefyMessage::AwsProviderConfig.instance
+      aws_config.setup_connection
+      @poller = Aws::SQS::QueuePoller.new(queue_url)
+    end
+
+    def receive_message
+
+      @poller.poll(wait_time_seconds: 10) do |received_message|
+        puts "Receiving Message from Broker"
+        puts "Message ID:   #{received_message.message_id}"
+        payload = JSON.parse(received_message.body)
+
+        process_message(payload["Message"])
+
+      end
+    end
+
+    def process_message(message)
+      raise "Must be implemented by a worker class"
+    end
+  end
+end
+

--- a/lib/pipefy_message/configuration.rb
+++ b/lib/pipefy_message/configuration.rb
@@ -13,7 +13,8 @@ module PipefyMessage
         endpoint: ENV["AWS_ENDPOINT"],
         access_key_id: ENV["AWS_ACCESS_KEY_ID"],
         secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-        region: ENV["AWS_REGION"] || "us-east-1"
+        region: ENV["AWS_REGION"] || "us-east-1",
+        stub_responses: true
       )
     end
   end

--- a/lib/pipefy_message/version.rb
+++ b/lib/pipefy_message/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PipefyMessage
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end

--- a/spec/base_consumer_spec.rb
+++ b/spec/base_consumer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe PipefyMessage::BaseConsumer do
+  context "when I try to consume a message from SQS broker" do
+    before do
+      ENV["AWS_ENDPOINT"] = "http://localhost:4566"
+      ENV["AWS_ACCESS_KEY_ID"] = "foo"
+      ENV["AWS_SECRET_ACCESS_KEY"] = "bar"
+    end
+    it "should consumer a message properly" do
+      consumer = PipefyMessage::BaseConsumer.new("http://localhost:4566/000000000000/pipefy-local-queue-test")
+      mocked_message = { message_id: "44c44782-fee1-6784-d614-43b73c0bda8d",
+                         receipt_handle: "2312dasdas1231221312321adsads",
+                         body: "{\"Message\": {\"foo\": \"bar\"}}" }
+
+      mocked_poller = Aws::SQS::QueuePoller.new("http://localhost:4566/000000000000/pipefy-local-queue-test",
+                                                { skip_delete: true })
+      mocked_poller.before_request { |stats| throw :stop_polling if stats.received_message_count > 0 }
+
+      mocked_element = Aws::SQS::Types::Message.new(mocked_message)
+      mocked_list = Aws::Xml::DefaultList.new
+      mocked_list.append(mocked_element)
+
+      mocked_poller.client.stub_responses(:receive_message, messages: mocked_list)
+      consumer.instance_variable_set(:@poller, mocked_poller)
+
+      result = consumer.consume_message
+      expect(result.received_message_count).to eq 1
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PipefyMessage::AwsProviderConfig do
       keys = PipefyMessage::AwsProviderConfig.instance.setup_connection
 
       expected = { endpoint: ENV["AWS_ENDPOINT"], access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-                   secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"], region: "us-east-1" }
+                   secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"], region: "us-east-1", stub_responses: true }
 
       expect(keys).to eq expected
     end


### PR DESCRIPTION
# ✨ New Feature

This MR contains the inclusion of SQS consumer with the long polling strategy.

# :repeat: Steps to reproduce

Run the following commands at the project root, on your terminal:

```

make build-app
make build-app-infra

export AWS_ENDPOINT="http://localhost:4566"
export AWS_ACCESS_KEY_ID=foo
export AWS_SECRET_ACCESS_KEY=bar

irb

require 'pipefy_message'
message = PipefyMessage::Test.new

message.publish
message.consume
```

# 🗂 Related cards

[[async] Create SQS consumer inside the gem](https://app.pipefy.com/open-cards/490987067)
