### PR TITLE
Export SNS and SQS libs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     pipefy_message (1.0.0)
+      aws-sdk-sns (~> 1.50.0)
+      aws-sdk-sqs (~> 1.49.0)
 
 GEM
   remote: https://rubygems.org/
@@ -99,4 +101,4 @@ DEPENDENCIES
   rubocop (~> 1.21)
 
 BUNDLED WITH
-   2.3.6
+   2.3.9

--- a/lib/pipefy_message.rb
+++ b/lib/pipefy_message.rb
@@ -11,7 +11,9 @@ require "logger"
 module PipefyMessage
   # Simple Test class to validate the project
   class Test
-    @log = Logger.new($stdout)
+    def initialize
+      @log = Logger.new($stdout)
+    end
 
     def publish
       payload = { foo: "bar" }

--- a/lib/pipefy_message/base_publisher.rb
+++ b/lib/pipefy_message/base_publisher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "aws-sdk-sqs"
-require "aws-sdk-sns"
 require "active_support"
 require "active_support/core_ext/string/inflections"
 require_relative "broker/aws/sns/publisher"

--- a/lib/pipefy_message/base_publisher.rb
+++ b/lib/pipefy_message/base_publisher.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "aws-sdk-sqs"
+require "aws-sdk-sns"
 require "active_support"
 require "active_support/core_ext/string/inflections"
 require_relative "broker/aws/sns/publisher"

--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -41,6 +41,8 @@ module PipefyMessage
                                  })
           @log.info("Message Published with ID #{result.message_id}")
           result
+        rescue StandardError
+          @log.error("Failed to publish message [#{message}]")
         end
       end
     end

--- a/pipefy_message.gemspec
+++ b/pipefy_message.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency  "aws-sdk-sns", "~> 1.50.0"
+  spec.add_dependency  "aws-sdk-sqs", "~> 1.49.0"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
# :art: Improvement

Including SQS and SNS into the `gemspec` file as a dependency, in order to export it to the clients (project who will use this gem).


# 🗂 Related cards

[[Async] Test Publisher Abstraction on Pipefy-core](https://app.pipefy.com/open-cards/501942353)
