### PR TITLE
Add error inspect to failed publish operation log

### DIFF
--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -42,8 +42,8 @@ module PipefyMessage
           result = topic.publish({ message: message.to_json, message_structure: " json " })
           @log.info(" Message Published with ID #{result.message_id}")
           result
-        rescue StandardError
-          @log.error("Failed to publish message [#{message}]")
+        rescue StandardError => e
+          @log.error("Failed to publish message [#{message}], error details: [#{e.inspect}]")
         end
       end
     end


### PR DESCRIPTION
# :art: Improvement

This PR contains an improvement at the publish operation error log. Basically, the details/cause of the error was added to the log message.

# 🗂 Related cards

[[Async] Test Publisher Abstraction on Pipefy-core](https://app.pipefy.com/open-cards/501942353)
