### PR TITLE
Adjust logger

### DIFF
--- a/lib/pipefy_message.rb
+++ b/lib/pipefy_message.rb
@@ -12,7 +12,7 @@ module PipefyMessage
   # Simple Test class to validate the project
   class Test
     def initialize
-      @log = PipefyMessage::CustomLogger.new.retrieve_logger
+      @log = PipefyMessage::CustomLogger.new
     end
 
     def publish

--- a/lib/pipefy_message/broker/aws/sns/publisher.rb
+++ b/lib/pipefy_message/broker/aws/sns/publisher.rb
@@ -14,7 +14,7 @@ module PipefyMessage
           aws_config = PipefyMessage::BrokerConfiguration::AwsProvider::ProviderConfig.instance
           aws_config.setup_connection
           @sns = Aws::SNS::Resource.new
-          @log = PipefyMessage::CustomLogger.new.retrieve_logger
+          @log = PipefyMessage::CustomLogger.new
           default_arn_prefix = "arn:aws:sns:us-east-1:000000000000:"
           @topic_arn_prefix = ENV["AWS_SNS_ARN_PREFIX"] || default_arn_prefix
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"

--- a/lib/pipefy_message/broker/aws/sqs/consumer.rb
+++ b/lib/pipefy_message/broker/aws/sqs/consumer.rb
@@ -13,7 +13,7 @@ module PipefyMessage
           PipefyMessage::BrokerConfiguration::AwsProvider::ProviderConfig.instance.setup_connection
           @poller = Aws::SQS::QueuePoller.new(queue_url)
           @wait_time_seconds = ENV["AWS_SQS_CONSUME_WAIT_TIME_SEC"] || 10
-          @log = PipefyMessage::CustomLogger.new.retrieve_logger
+          @log = PipefyMessage::CustomLogger.new
         end
 
         def consume_message

--- a/lib/pipefy_message/logger.rb
+++ b/lib/pipefy_message/logger.rb
@@ -7,17 +7,36 @@ require "logger"
 module PipefyMessage
   # Custom Logger class to centralize and deal with logs needs
   class CustomLogger
-    def retrieve_logger
-      logger = Logger.new($stdout)
-      log_level = ENV.fetch("ASYNC_LOG_LEVEL", "DEBUG")
-      logger.level = log_level
+    def initialize
+      @logger = Logger.new($stdout)
+      @is_log_enable = ENV.fetch("ASYNC_ENABLE_NON_ERROR_LOGS", "true") == "true"
 
-      logger.formatter = proc do |severity, datetime, progname, msg|
-        { level: severity != "ERROR" ? log_level : severity, timestamp: datetime.to_s,
-          app: progname, context: "async_processing", message: msg }.to_json + $INPUT_RECORD_SEPARATOR
+      @logger.formatter = proc do |severity, datetime, progname, msg|
+        { level: severity, timestamp: datetime.to_s, app: progname,
+          context: "async_processing", message: msg }.to_json + $INPUT_RECORD_SEPARATOR
       end
+    end
 
-      logger
+    def info(message)
+      return unless @is_log_enable
+
+      @logger.info(message)
+    end
+
+    def debug(message)
+      return unless @is_log_enable
+
+      @logger.debug(message)
+    end
+
+    def warn(message)
+      return unless @is_log_enable
+
+      @logger.warn(message)
+    end
+
+    def error(message)
+      @logger.error(message)
     end
   end
 end


### PR DESCRIPTION
# :art: Improvement

This PR contains an improvement in the logger, due to the costs of DataDog by ingesting them.
As accorded with the SRE team, JSON format will be used as the standard and only the ERROR logs will be sent to DataDog by default.

The other levels will be controlled by an environment variable to decide when they will be logged.

# :repeat: Steps to reproduce

Run the following commands at the project root, on your terminal:

``` console

export AWS_ENDPOINT="http://localhost:4566"
export AWS_ACCESS_KEY_ID=foo
export AWS_SECRET_ACCESS_KEY=bar
export ENABLE_AWS_CLIENT_CONFIG=true

make build-app
make build-app-infra

irb
```

On the IRB console run:

```ruby
require 'pipefy_message'
message = PipefyMessage::Test.new
message.publish
```

The output of logs should be something like:

```bash
{"level":"INFO","timestamp":"2022-03-31 15:39:15 -0300","app":null,"context":"async_processing","message":"Publishing a json message to topic arn:aws:sns:us-east-1:000000000000:pipefy-local-topic"}
{"level":"INFO","timestamp":"2022-03-31 15:39:15 -0300","app":null,"context":"async_processing","message":" Message Published with ID 42ed8557-d862-468a-aa36-2bd0a4b9e6cf"}
{:message_id=>"42ed8557-d862-468a-aa36-2bd0a4b9e6cf", :sequence_number=>nil}
=> nil
``` 


# 🗂 Related cards

[[Async] Adjust logger](https://app.pipefy.com/open-cards/513827178)
