### PR TITLE
refact: remove validation Aws.config

### DIFF
--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -13,8 +13,10 @@ module PipefyMessage
     desc "start", "Starts PipefyMessage consumer"
     method_option :worker, aliases: "-w", type: :string, desc: "Worker to load"
     method_option :rails, aliases: "-R", type: :boolean, desc: "Load Rails", default: false
+    method_option :pidfile,     aliases: '-P', type: :string,  desc: 'Path to pidfile'
     def start
       PipefyMessage::Runner.instance.initialize_rails if options[:rails]
+      PipefyMessage::Runner.instance.write_pid(options) if options[:pidfile]
       PipefyMessage::Runner.instance.run(options[:worker]) if options[:worker]
     end
   end
@@ -33,6 +35,12 @@ module PipefyMessage
         require File.expand_path("config/application.rb")
         require File.expand_path("config/environment.rb")
       end
+    end
+
+    def write_pid(options)
+      return unless (path = options[:pidfile])
+
+      File.open(path, 'w') { |f| f.puts(Process.pid) }
     end
 
     def run(worker)

--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -13,7 +13,7 @@ module PipefyMessage
     desc "start", "Starts PipefyMessage consumer"
     method_option :worker, aliases: "-w", type: :string, desc: "Worker to load"
     method_option :rails, aliases: "-R", type: :boolean, desc: "Load Rails", default: false
-    method_option :pidfile, aliases: "-P", type: :string,  desc: "Path to pidfile"
+    method_option :pidfile, aliases: "-P", type: :string, desc: "Path to pidfile"
     def start
       PipefyMessage::Runner.instance.initialize_rails if options[:rails]
       PipefyMessage::Runner.instance.write_pid(options) if options[:pidfile]
@@ -40,7 +40,7 @@ module PipefyMessage
     def write_pid(options)
       return unless (path = options[:pidfile])
 
-      File.open(path, 'w') { |f| f.puts(Process.pid) }
+      File.open(path, "w") { |f| f.puts(Process.pid) }
     end
 
     def run(worker)

--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -13,7 +13,7 @@ module PipefyMessage
     desc "start", "Starts PipefyMessage consumer"
     method_option :worker, aliases: "-w", type: :string, desc: "Worker to load"
     method_option :rails, aliases: "-R", type: :boolean, desc: "Load Rails", default: false
-    method_option :pidfile,     aliases: '-P', type: :string,  desc: 'Path to pidfile'
+    method_option :pidfile, aliases: "-P", type: :string,  desc: "Path to pidfile"
     def start
       PipefyMessage::Runner.instance.initialize_rails if options[:rails]
       PipefyMessage::Runner.instance.write_pid(options) if options[:pidfile]

--- a/lib/pipefy_message/providers/aws_client/aws_client.rb
+++ b/lib/pipefy_message/providers/aws_client/aws_client.rb
@@ -14,10 +14,7 @@ module PipefyMessage
       ##
       # Sets up AWS options the first time an AWS service is used.
       def self.aws_setup
-        return unless Aws.config.empty?
-
         logger.info({ message_text: "AWS configurations set" })
-
         Aws.config.update(retrieve_config)
       end
 

--- a/spec/providers/aws/aws_client_spec.rb
+++ b/spec/providers/aws/aws_client_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe PipefyMessage::Providers::AwsClient do
       TestClient.new
 
       ENV["AWS_CLI_STUB_RESPONSE"] = "false"
+      ENV["ENABLE_AWS_CLIENT_CONFIG"] = "false"
       TestClient.new
 
       expect(Aws.config).to eq aws_opts


### PR DESCRIPTION
# ✨ New Feature

To work with k8s we need to create a pidfile to check with `stat` command. If we have some problem with the consumer, the application will stop and the pidfile will be removed and k8s will reset the pod because `stat` command.




