### PR TITLE
Refactor queue URLs returned by AWS SDK SQS client to use HTTPS

### DIFF
--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -22,11 +22,7 @@ module PipefyMessage
           @topic_arn_prefix = ENV.fetch("AWS_SNS_ARN_PREFIX", "arn:aws:sns:us-east-1:000000000000")
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
 
-          queue_url = @sqs.get_queue_url({ queue_name: @config[:queue_name] }).queue_url
-
-          queue_url = queue_url.sub("http:", "https:")
-          # The string returned by the SQS client object is frozen,
-          # so we can't use something like sub!.
+          queue_url = @sqs.get_queue_url({ queue_name: @config[:queue_name] }).queue_url.sub(%r{^http://}, "https://")
 
           @poller = Aws::SQS::QueuePoller.new(queue_url, { client: @sqs })
         rescue StandardError => e

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -23,6 +23,11 @@ module PipefyMessage
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
 
           queue_url = @sqs.get_queue_url({ queue_name: @config[:queue_name] }).queue_url
+
+          queue_url = queue_url.sub("http:", "https:")
+          # The string returned by the SQS client object is frozen,
+          # so we can't use something like sub!.
+
           @poller = Aws::SQS::QueuePoller.new(queue_url, { client: @sqs })
         rescue StandardError => e
           raise PipefyMessage::Providers::Errors::ResourceError, e.message

--- a/spec/providers/aws/sqs_broker_spec.rb
+++ b/spec/providers/aws/sqs_broker_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe PipefyMessage::Providers::AwsClient::SqsBroker do
 
       expect(sqs_broker.instance_variable_get(:@poller).instance_variable_get(:@queue_url)).to eq "https://fake/url"
     end
-
   end
 
   describe "#poller" do

--- a/spec/providers/aws/sqs_broker_spec.rb
+++ b/spec/providers/aws/sqs_broker_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe PipefyMessage::Providers::AwsClient::SqsBroker do
 
       expect(sqs_broker.instance_variable_get(:@config)).to eq sqs_opts
     end
+
+    it "should convert HTTP URLs to HTTPS" do
+      mock_sqs_client = instance_double("Aws::SQS::Client")
+      allow(mock_sqs_client).to receive(:get_queue_url).and_return(Aws::SQS::Types::GetQueueUrlResult.new(queue_url: "http://fake/url"))
+      allow(Aws::SQS::Client).to receive(:new).and_return(mock_sqs_client)
+
+      sqs_broker = described_class.new(queue_name: sqs_opts[:queue_name])
+
+      expect(sqs_broker.instance_variable_get(:@poller).instance_variable_get(:@queue_url)).to eq "https://fake/url"
+    end
+
   end
 
   describe "#poller" do


### PR DESCRIPTION
# ✨ New Feature

Refactor queue URLs returned by AWS SDK SQS client to use HTTPS. This is required for the gem to work on the my-stack environment, because a Cloudflare rule enforces the use of HTTPS on *.pipefy.net by redirecting all HTTP requests to port 443, but the AWS SDK does not seem to follow the redirection.

# 🗂 Related cards

[[Async] Handle My-Stack Queue resolution](https://app.pipefy.com/open-cards/533971227)
