### PR TITLE
fix: Fix partial refactor of elapsed_time

### DIFF
--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -15,8 +15,8 @@ module PipefyMessage
     method_option :rails, aliases: "-R", type: :boolean, desc: "Load Rails", default: false
     method_option :pidfile, aliases: "-P", type: :string, desc: "Path to pidfile"
     def start
-      PipefyMessage::Runner.instance.initialize_rails if options[:rails]
       PipefyMessage::Runner.instance.write_pid(options) if options[:pidfile]
+      PipefyMessage::Runner.instance.initialize_rails if options[:rails]
       PipefyMessage::Runner.instance.run(options[:worker]) if options[:worker]
     end
   end

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -81,7 +81,7 @@ module PipefyMessage
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info({
-                        duration_ms: elapsed_time_ms,
+                        duration_ms: elapsed_time,
                         message_text: "Message received by consumer poller, processed " \
                                       "in #{elapsed_time} milliseconds"
                       })

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -81,9 +81,9 @@ module PipefyMessage
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info({
-                        duration_ms: elapsed_time,
+                        duration_ms: elapsed_time_ms,
                         message_text: "Message received by consumer poller, processed " \
-                                      "in #{elapsed_time} milliseconds"
+                                      "in #{elapsed_time_ms} milliseconds"
                       })
         end
       rescue PipefyMessage::Providers::Errors::ResourceError => e


### PR DESCRIPTION
When we changed the way we time message processing today, one instance of `elapsed_time` was accidentally changed to `elapsed_time_ms`... and, somehow, no person or linter caught that :upside_down_face: 