### PR TITLE
Fix for queue name parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     logger (1.5.1)
     method_source (1.0.0)
     minitest (5.15.0)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -116,6 +118,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -61,7 +61,7 @@ module PipefyMessage
         end
 
         ##
-        #
+        # Adds the staging prefix to queue names where applicable.
         def handle_queue_name(queue_name)
           @is_staging ? "#{queue_name}-staging" : queue_name
         end

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -61,7 +61,7 @@ module PipefyMessage
         end
 
         ##
-        # Adds the staging prefix to queue names where applicable.
+        # Adds the staging suffix to queue names where applicable.
         def handle_queue_name(queue_name)
           @is_staging ? "#{queue_name}-staging" : queue_name
         end

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -20,8 +20,8 @@ module PipefyMessage
           logger.debug({ message_text: "SQS client created" })
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
 
-          @queue_url = @sqs.get_queue_url({ queue_name: @config[:queue_name] }).queue_url.sub(%r{^http://}, "https://")
-          @queue_url = (@is_staging ? "#{@queue_url}-staging" : @queue_url)
+          @queue_url = @sqs.get_queue_url({ queue_name: handle_queue_name(@config[:queue_name]) })
+                           .queue_url.sub(%r{^http://}, "https://")
 
           @poller = Aws::SQS::QueuePoller.new(@queue_url, { client: @sqs })
         rescue StandardError => e
@@ -58,6 +58,12 @@ module PipefyMessage
         # Adds the queue name to logs, if not already present.
         def build_log_hash(arg)
           { queue_name: @config[:queue_name], message_text: arg }
+        end
+
+        ##
+        #
+        def handle_queue_name(queue_name)
+          @is_staging ? "#{queue_name}-staging" : queue_name
         end
       end
     end


### PR DESCRIPTION
# 🐞 The problem

The queue suffix for the staging env was not being handled correctly.

# 💻 The fix

The code statement for handling it was refactored and a unit test was added.


# 🗂 Related cards

[[Async] Include consumer deployment to my-stack env](https://app.pipefy.com/open-cards/535288515)