### PR TITLE
Include custom data into published messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pipefy_message (0.1.1)
+    pipefy_message (2.0.0)
       aws-sdk-sns (~> 1.50.0)
       aws-sdk-sqs (~> 1.49.0)
       thor

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ bundle exec pipefymessage -w ConsumerExampleClass -R
 To test changes without installing this dependency on your application, on your terminal go to the project root and execute:
     
 ```shell
-  export ENABLE_AWS_CLIENT_CONFIG=true
+  export ENABLE_AWS_CLIENT_CONFIG="true"
+  export ASYNC_APP_ENV="development" 
     
   make build-app
   make build-app-infra

--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ bundle exec pipefymessage -w ConsumerExampleClass -R
 ### Development - Test
 
 To test changes without installing this dependency on your application, on your terminal go to the project root and execute:
-    
+
+> **:information_source: Environment Variables info.**  
+>> ENABLE_AWS_CLIENT_CONFIG is used to allow us to connect in the localstack service instead AWS
+> 
+>> ASYNC_APP_ENV is used to specify the environment and handle some actions/adjustments on each one like protocol, queue name, and so on
+
 ```shell
   export ENABLE_AWS_CLIENT_CONFIG="true"
   export ASYNC_APP_ENV="development" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   localstack:
     container_name: localstack
-    image: localstack/localstack-light:0.11.5
+    image: localstack/localstack-light:0.14.3
     environment:
       AWS_DEFAULT_REGION: us-east-1
       LOCALSTACK_SERVICES: sns,sqs

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -71,10 +71,11 @@ module PipefyMessage
 
         logger.info({ message_text: "Calling consumer poller" })
 
-        build_consumer_instance.poller do |payload|
+        build_consumer_instance.poller do |payload, message_attributes|
           logger.info({
                         message_text: "Message received by poller to be processed by consumer",
-                        received_message: payload
+                        received_message: payload,
+                        message_attributes: message_attributes
                       })
 
           obj.perform(payload["Message"])

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -71,11 +71,11 @@ module PipefyMessage
 
         logger.info({ message_text: "Calling consumer poller" })
 
-        build_consumer_instance.poller do |payload, message_attributes|
+        build_consumer_instance.poller do |payload, metadata|
           logger.info({
                         message_text: "Message received by poller to be processed by consumer",
                         received_message: payload,
-                        message_attributes: message_attributes
+                        metadata: metadata
                       })
 
           obj.perform(payload["Message"])

--- a/lib/pipefy_message/providers/aws_client/sns_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sns_broker.rb
@@ -28,7 +28,7 @@ module PipefyMessage
         ##
         # Publishes a message with the given payload to the SNS topic
         # with topic_name.
-        def publish(payload, topic_name, context = nil)
+        def publish(payload, topic_name, context = "NO_CONTEXT_PROVIDED")
           message = prepare_payload(payload)
           topic_arn = @topic_arn_prefix + (@is_staging ? "#{topic_name}-staging" : topic_name)
           topic = @sns.topic(topic_arn)
@@ -36,7 +36,7 @@ module PipefyMessage
           logger.info(
             { topic_arn: topic_arn,
               payload: payload,
-              message_text: "Attempting to publish a json message to topic #{topic_arn}" }
+              message_text: "Attempting to publish a json message to topic #{topic_arn}}" }
           )
 
           result = topic.publish({ message: message.to_json, message_structure: " json ",

--- a/lib/pipefy_message/providers/aws_client/sns_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sns_broker.rb
@@ -36,7 +36,7 @@ module PipefyMessage
           logger.info(
             { topic_arn: topic_arn,
               payload: payload,
-              message_text: "Attempting to publish a json message to topic #{topic_arn}}" }
+              message_text: "Attempting to publish a json message to topic #{topic_arn}" }
           )
 
           result = topic.publish({ message: message.to_json, message_structure: " json ",

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -20,8 +20,8 @@ module PipefyMessage
           logger.debug({ message_text: "SQS client created" })
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
 
-          @queue_url = @sqs.get_queue_url({ queue_name: handle_queue_name(@config[:queue_name]) })
-                           .queue_url.sub(%r{^http://}, "https://")
+          @queue_url = handle_queue_protocol(@sqs.get_queue_url({ queue_name: handle_queue_name(@config[:queue_name]) })
+                           .queue_url)
 
           @poller = Aws::SQS::QueuePoller.new(@queue_url, { client: @sqs })
         rescue StandardError => e
@@ -64,6 +64,10 @@ module PipefyMessage
         # Adds the staging suffix to queue names where applicable.
         def handle_queue_name(queue_name)
           @is_staging ? "#{queue_name}-staging" : queue_name
+        end
+
+        def handle_queue_protocol(queue_url)
+          ENV["ASYNC_APP_ENV"] == "development" ? queue_url : queue_url.sub(%r{^http://}, "https://")
         end
       end
     end

--- a/lib/pipefy_message/version.rb
+++ b/lib/pipefy_message/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PipefyMessage
-  VERSION = "0.1.1"
+  VERSION = "2.0.0"
 end

--- a/spec/providers/aws/sns_broker_spec.rb
+++ b/spec/providers/aws/sns_broker_spec.rb
@@ -38,5 +38,29 @@ RSpec.describe PipefyMessage::Providers::AwsClient::SnsBroker do
       expect(result.message_id).to eq "messageId"
       expect(result.sequence_number).to eq "String"
     end
+
+    it "should receive payload with expected message attributes" do
+      sns_broker = described_class.new
+      sns_client_mock = spy(Aws::SNS::Resource.new)
+      sns_topic_mock = spy(Aws::SNS::Topic.new(arn: "foo", client: Aws::SNS::Client.new({})))
+      allow(sns_client_mock).to receive(:topic).and_return(sns_topic_mock)
+
+      sns_broker.instance_variable_set(:@sns, sns_client_mock)
+      allow(SecureRandom).to receive(:uuid).and_return("15075c9d-7337-4f70-be02-2732aff2c2f7")
+      payload = { foo: "bar" }
+      topic_name = "pipefy-local-topic"
+
+      sns_broker.publish(payload, topic_name)
+
+      expected_payload = { message: "{\"default\":{\"foo\":\"bar\"}}",
+                           message_attributes: { "context" => { data_type: "String",
+                                                                string_value: "NO_CONTEXT_PROVIDED" },
+                                                 "correlationId" =>
+                                   { data_type: "String",
+                                     string_value: "15075c9d-7337-4f70-be02-2732aff2c2f7" } },
+                           message_structure: " json " }
+
+      expect(sns_topic_mock).to have_received(:publish).with(expected_payload)
+    end
   end
 end


### PR DESCRIPTION
# ✨ New Feature

This MR contains the inclusion of custom data into the SNS message attributes. The motivation behind it is to make tracing and debugging easier.

# :repeat: Steps to reproduce

Run the following commands at the project root, on your terminal:

```
make build-app
make build-app-infra

export ENABLE_AWS_CLIENT_CONFIG="true"
export ASYNC_APP_ENV="development" 

irb
```

At the `irb` session run:

```ruby
require_relative 'lib/samples/my_awesome_publisher.rb'
publisher = MyAwesomePublisher.new
publisher.publish
```

Open a new `irb` session and run:

```ruby
require_relative 'lib/samples/my_awesome_consumer.rb'
MyAwesomeConsumer.process_message
```

At the consumer JSON logs it's expected to have an entry for MessageAttributes with something like this:
```
"message_attributes":{"correlationId":"{:string_value=>\"4b825d57-8ad3-4848-a932-10c5075fec0e\", :binary_value=>nil, :string_list_values=>[], :binary_list_values=>[], :data_type=>\"String\"}","context":"{:string_value=>\"NO_CONTEXT_PROVIDED\", :binary_value=>nil, :string_list_values=>[], :binary_list_values=>[], :data_type=>\"String\"}"}
```


# 🗂 Related cards

[[Async] Include custom data into published messages](https://app.pipefy.com/open-cards/529344267)
