### PR TITLE
Add context parameter to publisher abstraction

### DIFF
--- a/lib/pipefy_message/providers/aws_client/sns_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sns_broker.rb
@@ -28,7 +28,8 @@ module PipefyMessage
         ##
         # Publishes a message with the given payload to the SNS topic
         # with topic_name.
-        def publish(payload, topic_name, context = "NO_CONTEXT_PROVIDED")
+        def publish(payload, topic_name, context = nil)
+          context = "NO_CONTEXT_PROVIDED" if context.nil?
           message = prepare_payload(payload)
           topic_arn = @topic_arn_prefix + (@is_staging ? "#{topic_name}-staging" : topic_name)
           topic = @sns.topic(topic_arn)

--- a/lib/pipefy_message/publisher.rb
+++ b/lib/pipefy_message/publisher.rb
@@ -14,8 +14,8 @@ module PipefyMessage
       @publisher_instance = build_publisher_instance
     end
 
-    def publish(message, topic)
-      @publisher_instance.publish(message, topic)
+    def publish(message, topic, context = nil)
+      @publisher_instance.publish(message, topic, context)
     end
 
     private

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -3,7 +3,7 @@
 require_relative "../lib/pipefy_message/providers/aws_client/sns_broker"
 
 class TestBroker
-  def publish(message, topic); end
+  def publish(message, topic, context = nil); end
 end
 
 RSpec.describe PipefyMessage::Publisher do
@@ -21,7 +21,7 @@ RSpec.describe PipefyMessage::Publisher do
     topic_name = "pipefy-local-topic"
     publisher.publish(payload, topic_name)
 
-    expect(test_broker).to have_received(:publish).with(payload, topic_name)
+    expect(test_broker).to have_received(:publish).with(payload, topic_name, nil)
   end
 
   context "when I try to publish a message to SNS broker" do
@@ -60,7 +60,7 @@ RSpec.describe PipefyMessage::Publisher do
       topic_name = "pipefy-local-topic"
       result = publisher.publish(payload, topic_name)
       expect(result).to eq mocked_return
-      expect(mocked_publisher_impl).to have_received(:publish).with(payload, topic_name)
+      expect(mocked_publisher_impl).to have_received(:publish).with(payload, topic_name, nil)
     end
   end
 end


### PR DESCRIPTION
# 🩹 Adjustment

This MR contains the inclusion of context parameter into the publisher abstraction as optional. The addition of that parameter was made at https://github.com/pipefy/pipefy_message/pull/26.

# :repeat: Steps to reproduce

Run the following commands at the project root, on your terminal:

```
make build-app
make build-app-infra

export ENABLE_AWS_CLIENT_CONFIG="true"
export ASYNC_APP_ENV="development" 

irb
```

At the `irb` session run:

```ruby
require_relative 'lib/samples/my_awesome_publisher.rb'
publisher = MyAwesomePublisher.new
publisher.publish
```

Open a new `irb` session and run:

```ruby
require_relative 'lib/samples/my_awesome_consumer.rb'
MyAwesomeConsumer.process_message
```

At the consumer JSON logs it's expected to have an entry for MessageAttributes with something like this:
```
"message_attributes":{"correlationId":"{:string_value=>\"4b825d57-8ad3-4848-a932-10c5075fec0e\", :binary_value=>nil, :string_list_values=>[], :binary_list_values=>[], :data_type=>\"String\"}","context":"{:string_value=>\"NO_CONTEXT_PROVIDED\", :binary_value=>nil, :string_list_values=>[], :binary_list_values=>[], :data_type=>\"String\"}"}
```


# 🗂 Related cards

[[Async] Include custom data into published messages](https://app.pipefy.com/open-cards/529344267)
