### PR TITLE
Support for immediate retry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pipefy_message (2.0.0)
+    pipefy_message (2.0.1)
       aws-sdk-sns (~> 1.50.0)
       aws-sdk-sqs (~> 1.49.0)
       thor

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ delete-app-infra:
 	@docker-compose down -v --remove-orphans
 
 build-app:
-	bundle install
+	bundle install --no-cache
 	gem build pipefy_message.gemspec
 	gem install pipefy_message-[0-9].[0-9].[0-9].gem
 

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -35,7 +35,7 @@ module PipefyMessage
     # To be defined by classes that include this module. Processes
     # messages received by the poller. Called by process_message from
     # an instance of the including class.
-    def perform(_message)
+    def perform(_message, _metadata)
       error_msg = includer_should_implement(__method__)
       raise NotImplementedError, error_msg
     end
@@ -79,7 +79,7 @@ module PipefyMessage
                       })
 
           retry_count = metadata["ApproximateReceiveCount"].to_i - 1
-          obj.perform(payload["Message"], retry_count)
+          obj.perform(payload["Message"], { retry_count: retry_count })
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info({

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -78,7 +78,8 @@ module PipefyMessage
                         metadata: metadata
                       })
 
-          obj.perform(payload["Message"])
+          retry_count = metadata["ApproximateReceiveCount"].to_i - 1
+          obj.perform(payload["Message"], retry_count)
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info({

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -39,10 +39,12 @@ module PipefyMessage
             logger.debug(build_log_hash("Message received by SQS poller on queue #{@queue_url}"))
 
             payload = JSON.parse(received_message.body)
-            yield(payload, received_message.message_attributes)
-
+            metadata = received_message.message_attributes.merge(received_message.attributes)
+            yield(payload, metadata)
           rescue StandardError => e
-            raise PipefyMessage::Providers::Errors::ResourceError, e.message
+            # error in the routine, skip delete to try the message again later with 30sec of delay
+            logger.error("Failed to process message, details #{e.inspect}")
+            throw :skip_delete
           end
         end
 

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -44,6 +44,9 @@ module PipefyMessage
           rescue StandardError => e
             # error in the routine, skip delete to try the message again later with 30sec of delay
             logger.error("Failed to process message, details #{e.inspect}")
+
+            throw e if e.instance_of?(NameError)
+
             throw :skip_delete
           end
         end

--- a/lib/pipefy_message/version.rb
+++ b/lib/pipefy_message/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PipefyMessage
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/lib/samples/my_awesome_consumer.rb
+++ b/lib/samples/my_awesome_consumer.rb
@@ -8,8 +8,8 @@ class MyAwesomeConsumer
   include PipefyMessage::Consumer
   options queue_name: "pipefy-local-queue"
 
-  def perform(message)
-    puts "Received message #{message} from broker"
+  def perform(message, retry_count)
+    puts "Received message #{message} from broker - retry #{retry_count}"
     ## Fill with our logic here
   end
 end

--- a/lib/samples/my_awesome_consumer.rb
+++ b/lib/samples/my_awesome_consumer.rb
@@ -8,8 +8,9 @@ class MyAwesomeConsumer
   include PipefyMessage::Consumer
   options queue_name: "pipefy-local-queue"
 
-  def perform(message, retry_count)
-    puts "Received message #{message} from broker - retry #{retry_count}"
+  def perform(message, metadata)
+    puts "Received message #{message} from broker - retry #{metadata[:retry_count]}"
     ## Fill with our logic here
+    raise StandardError
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-class MockBroker
-  def poller; end
-end
+require "aws-sdk-core"
+require "pipefy_message/providers/aws_client/sqs_broker"
 
 class MockBrokerFail
   def poller
@@ -19,21 +18,68 @@ class TestConsumer
   end
 end
 
+class MockTestConsumerFail
+  include PipefyMessage::Consumer
+  options broker: "aws", queue_name: "pipefy-local-queue"
+
+  def perform(message, metadata)
+    puts "#{message} - #{metadata}"
+    throw StandardError
+  end
+end
+
 RSpec.describe PipefyMessage::Consumer do
   before do
     ENV["ENABLE_AWS_CLIENT_CONFIG"] = "true"
     ENV["AWS_CLI_STUB_RESPONSE"] = "true"
+
+    Aws.config[:sqs] = {
+      stub_responses: {
+        receive_message: [
+          { messages: [{ message_id: "950b674b-0e9f-4336-8a32-7502dbf2eb36",
+                         receipt_handle: "950b674b-0e9f-4336-8a32-7502dbf2eb36", body: { foo: "bar" }.to_json,
+                         attributes: { "ApproximateReceiveCount" => "1" } }] }
+        ],
+        get_queue_url: [
+          { queue_url: "http://localhost" }
+        ]
+      }
+    }
+  end
+  after do
+    Aws.config = {} # undoing changes
+    # (to avoid test "cross-contamination")
   end
   describe "#perform" do
-    context "successful polling" do
+    context "successful polling with SQS Broker" do
       it "should call #perform from child instance when #process_message is called" do
-        mock_broker = instance_double("MockBroker")
-        allow(mock_broker).to receive(:poller).with(no_args)
+        sqs_mock_broker = PipefyMessage::Providers::AwsClient::SqsBroker.new({ queue_name: "pipefy-local-queue" })
+        poller = sqs_mock_broker.instance_variable_get(:@poller)
+        poller.before_request do |stats|
+          throw :stop_polling if stats.received_message_count >= 1
+        end
 
-        allow(TestConsumer).to receive(:build_consumer_instance).and_return(mock_broker)
+        allow(TestConsumer).to receive(:build_consumer_instance).and_return(sqs_mock_broker)
 
         TestConsumer.process_message
-        expect(mock_broker).to have_received(:poller)
+      end
+    end
+
+    context "continue polling after failure with SQS broker" do
+      it "should continue calling #perform after any failure" do
+        sqs_mock_broker = PipefyMessage::Providers::AwsClient::SqsBroker.new({ queue_name: "pipefy-local-queue" })
+        poller = sqs_mock_broker.instance_variable_get(:@poller)
+        received_message_counter = 0
+
+        poller.before_request do |stats|
+          received_message_counter = stats.received_message_count
+          throw :stop_polling if stats.received_message_count == 2
+        end
+
+        allow(MockTestConsumerFail).to receive(:build_consumer_instance).and_return(sqs_mock_broker)
+
+        MockTestConsumerFail.process_message
+        expect(received_message_counter).to be == 2
       end
     end
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -14,8 +14,8 @@ class TestConsumer
   include PipefyMessage::Consumer
   options broker: "aws", queue_name: "pipefy-local-queue"
 
-  def perform(message)
-    puts message
+  def perform(message, metadata)
+    puts "#{message} - #{metadata}"
   end
 end
 
@@ -45,7 +45,7 @@ RSpec.describe PipefyMessage::Consumer do
     end
 
     it "should fail if called directly from the parent class" do
-      expect { TestConsumer.perform("message") }.to raise_error NotImplementedError
+      expect { TestConsumer.perform("message", {}) }.to raise_error NotImplementedError
     end
   end
 


### PR DESCRIPTION
# ✨ New Feature

In order to improve the reliability of our gem, it's necessary to provide a retry mechanism for errors during the consumer message processing.

# :repeat: Steps to reproduce

Add the following line to the file `lib/samples/my_awesome_consumer.rb` on line 13:

```ruby
    raise StandardError
```

Then, run the commands bellow:

```ruby
require_relative 'lib/samples/my_awesome_publisher.rb'
publisher = MyAwesomePublisher.new
publisher.publish
```

Open a new `irb` session and run:

```ruby
require_relative 'lib/samples/my_awesome_consumer.rb'
MyAwesomeConsumer.process_message
```

The expected output is some logs with the information of retry number, like:

```console
Received message {"foo": "bar"} from broker - retry 0
Received message {"foo": "bar"} from broker - retry 1
Received message {"foo": "bar"} from broker - retry 2
Received message {"foo": "bar"} from broker - retry 3
```

# 🗂 Related cards

[[Async] Create Retry mechanism for consumer](https://app.pipefy.com/open-cards/529341504)
