### PR TITLE
Eh/main/fix log mystack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ gem "rake", "~> 13.0"
 
 group :development, :test do
   gem "pry"
+  gem "pry-byebug"
   gem "pry-doc"
-  gem 'pry-byebug'
   gem "rspec", "~> 3.0"
   gem "rubocop", "~> 1.21"
   gem "solargraph"

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "rake", "~> 13.0"
 group :development, :test do
   gem "pry"
   gem "pry-doc"
+  gem 'pry-byebug'
   gem "rspec", "~> 3.0"
   gem "rubocop", "~> 1.21"
   gem "solargraph"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     backport (1.2.0)
     benchmark (0.2.0)
+    byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     diff-lcs (1.5.0)
@@ -46,7 +47,11 @@ GEM
       kramdown (~> 2.0)
     logger (1.5.1)
     method_source (1.0.0)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
@@ -57,6 +62,9 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     pry-doc (1.3.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
@@ -118,6 +126,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 
@@ -128,6 +137,7 @@ DEPENDENCIES
   logger
   pipefy_message!
   pry
+  pry-byebug
   pry-doc
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+$stdout = STDOUT
+$stdout.sync = true
+
 require "rubygems"
 require "singleton"
 require "thor"
@@ -15,6 +18,7 @@ module PipefyMessage
     method_option :rails, aliases: "-R", type: :boolean, desc: "Load Rails", default: false
     method_option :pidfile, aliases: "-P", type: :string, desc: "Path to pidfile"
     def start
+      puts "Starting PipefyMessage Consumer"
       PipefyMessage::Runner.instance.write_pid(options) if options[:pidfile]
       PipefyMessage::Runner.instance.initialize_rails if options[:rails]
       PipefyMessage::Runner.instance.run(options[:worker]) if options[:worker]
@@ -35,6 +39,8 @@ module PipefyMessage
         require File.expand_path("config/application.rb")
         require File.expand_path("config/environment.rb")
       end
+
+      puts "Booted Rails #{::Rails.version} application in #{ ENV["RAILS_ENV"]} environment" 
     end
 
     def write_pid(options)
@@ -44,7 +50,12 @@ module PipefyMessage
     end
 
     def run(worker)
-      worker.constantize.process_message
+      begin
+        worker.constantize.process_message 
+      rescue Interrupt
+        puts "Shutting down"
+        exit(0)
+      end
     end
   end
 end

--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -40,7 +40,7 @@ module PipefyMessage
         require File.expand_path("config/environment.rb")
       end
 
-      puts "Booted Rails #{::Rails.version} application in #{ ENV["RAILS_ENV"]} environment" 
+      puts "Booted Rails #{::Rails.version} application in #{ ENV["RAILS_ENV"]} environment"
     end
 
     def write_pid(options)

--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -40,7 +40,8 @@ module PipefyMessage
         require File.expand_path("config/environment.rb")
       end
 
-      puts "Booted Rails #{::Rails.version} application in #{ ENV["RAILS_ENV"]} environment"
+      environment = ENV.fetch("RAILS_ENV")
+      puts "Booted Rails #{::Rails.version} application in #{environment} environment"
     end
 
     def write_pid(options)
@@ -50,12 +51,10 @@ module PipefyMessage
     end
 
     def run(worker)
-      begin
-        worker.constantize.process_message 
-      rescue Interrupt
-        puts "Shutting down"
-        exit(0)
-      end
+      worker.constantize.process_message
+    rescue Interrupt
+      puts "Shutting down"
+      exit(0)
     end
   end
 end

--- a/lib/pipefy_message/logging.rb
+++ b/lib/pipefy_message/logging.rb
@@ -28,7 +28,7 @@ module PipefyMessage
     ##
     # Configuration for a logger created by the Ruby logger gem.
     def self.logger_setup
-      Logger.new($stdout).tap do |logger|
+      Logger.new(STDOUT).tap do |logger|
         logger.level = LOG_LEVELS.index(ENV.fetch("ASYNC_LOG_LEVEL", "INFO")) || Logger::ERROR
 
         logger.formatter = proc do |severity, datetime, progname, msg|

--- a/lib/pipefy_message/logging.rb
+++ b/lib/pipefy_message/logging.rb
@@ -28,7 +28,7 @@ module PipefyMessage
     ##
     # Configuration for a logger created by the Ruby logger gem.
     def self.logger_setup
-      Logger.new(STDOUT).tap do |logger|
+      Logger.new($stdout).tap do |logger|
         logger.level = LOG_LEVELS.index(ENV.fetch("ASYNC_LOG_LEVEL", "INFO")) || Logger::ERROR
 
         logger.formatter = proc do |severity, datetime, progname, msg|


### PR DESCRIPTION
# 🐞 The problem

In order to track the consumer message processing, we need to have logs from the application to understand if it's working or not.

How can we reproduce this bug if needed?

Check the app-core-consumer_pipefy_messages application at any my-stack namespace and understand why we don't have logs in the pod stdout.

You can use this command to verify the logs:

`kubectl logs -f REPLACE_WITH_POD_NAME -n REPLACE_WITH_YOUR_NAMESPACE_AT_MYSTACK`

# 💻 The fix

Set STDOUT as default for thor and configure it to be synced, add some logs to test  

# 🖼 Screenshots

| Before 🐛 | After ✨ |
| --------- | -------- |
|           |          |

# 🗂 Related cards

[Card Title](https://app.pipefy.com/open-cards/545777999)

# 🔥 The impact

Link here the Datadog, Sentry or other metrics that shows the impact on our users.
- [Datadog]()
- [Sentry]()

# A few reminders

- If rake tasks or environment variables were added/changed - let the DevOps team know.
- CardUiPresenter is cached - be careful, keep backward compatibility.
- If there is a FE change, make sure that it works on all our supported browsers - including IE!

Check the supported deployment tags if you need to just sync k8s manifests or deploy a hotfix:

https://git.pipefy.net/pipefy/pipefy-core/-/blob/master/doc/deployment-tags.md