### PR TITLE
:bug: Get start time when getting a payload and not when creating the…

### DIFF
--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -66,12 +66,12 @@ module PipefyMessage
       # from which the call to process_message was made (see perform
       # method in the parent module).
       def process_message
-        start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
         obj = new
 
         logger.info({ message_text: "Calling consumer poller" })
 
         build_consumer_instance.poller do |payload, metadata|
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
           logger.info({
                         message_text: "Message received by poller to be processed by consumer",
                         received_message: payload,


### PR DESCRIPTION
# ✨ New Feature

Fix processing time calculation.

# :repeat: Steps to reproduce

The way it was done, it was always considering the time the processor was created instead of when the message was received.

# 🖼 Screenshots

Look at ` new-async-consumer` consumer logs. After fixing the calculation, the processing time (field `duration_ms`) isn't monotonically increasing anymore.

# 🗂 Related cards

[Card Title](https://app.pipefy.com/open-cards/cardId)
