### PR TITLE
feat: Send cid back to consumer in perform call metadata

### DIFF
--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -84,7 +84,7 @@ module PipefyMessage
                                   }, context, correlation_id, event_id))
 
           retry_count = metadata["ApproximateReceiveCount"].to_i - 1
-          obj.perform(payload["Message"], { retry_count: retry_count })
+          obj.perform(payload["Message"], { retry_count: retry_count, correlation_id: correlation_id })
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info(log_context({

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -84,7 +84,7 @@ module PipefyMessage
                                   }, context, correlation_id, event_id))
 
           retry_count = metadata["ApproximateReceiveCount"].to_i - 1
-          obj.perform(payload["Message"], { retry_count: retry_count, correlation_id: correlation_id })
+          obj.perform(payload["Message"], { retry_count: retry_count, context: context, correlation_id: correlation_id })
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info(log_context({

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -84,7 +84,8 @@ module PipefyMessage
                                   }, context, correlation_id, event_id))
 
           retry_count = metadata["ApproximateReceiveCount"].to_i - 1
-          obj.perform(payload["Message"], { retry_count: retry_count, context: context, correlation_id: correlation_id })
+          obj.perform(payload["Message"],
+                      { retry_count: retry_count, context: context, correlation_id: correlation_id })
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info(log_context({


### PR DESCRIPTION
# ✨ New Feature

This PR inserts the `context` variable, as well as the correlation ID provided by PR #33, into the `metadata` hash argument passed to the consumer `perform` method. This allows subsequent processing happening outside the context of `pipefy_message` to carry on using the same context and correlation ID (for logging and such).

Note: In a synchronous discussion that took place today (Friday, Aug 5), we decided not to move forward with [this previously considered approach (Slack link)](https://pipefy.slack.com/archives/C03NBL5L7RQ/p1659558599924279), as we realized there would probably be more to refactor in the future re: Telemetry in pipefy-core, consumer initialization, etc. that might require further changes in this gem as well. Thus, we decided to move on with this solution for now rather than do one more refactor that might prove temporary in the future.

# :repeat: Steps to reproduce

You could follow the same steps indicated in PR #33, but alter the printed message in `lib/samples/my_awesome_consumer.rb` to display the entire `metadata` argument, rather than just `metadata[:retry_count]`. The `context` and `correlation_id` received by the consumer in the `perform` call should be the same given in the publisher `publish` call (`test` and `123`).

# 🗂 Related cards

[[Async] Add correlation_id and event_id to messages and logs](https://app.pipefy.com/open-cards/559661127)
