### PR TITLE
:sparkles: Convert metadata before sending it to consumer

### DIFF
--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -73,9 +73,9 @@ module PipefyMessage
         build_consumer_instance.poller do |payload, metadata|
           start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
 
-          context = metadata["context"]
-          correlation_id = metadata["correlationId"]
-          event_id = metadata["eventId"]
+          context = metadata[:context]
+          correlation_id = metadata[:correlationId]
+          event_id = metadata[:eventId]
 
           logger.info(log_context({
                                     message_text: "Message received by poller to be processed by consumer",


### PR DESCRIPTION
# ✨ New Feature

Convert `metadata` structure: instead of just passing it along, convert it to an ordinary `Hash` without data structures that comes from AWS SDK.

# :repeat: Steps to reproduce

Publish and consume messages sending `correlation_id` and/or other values at `context` argument.

# 🖼 Screenshots

| Before 🐛 | After ✨ |
| --------- | -------- |
|  ![image](https://user-images.githubusercontent.com/8394463/183667975-8a47ce8f-e89c-4db2-83b3-4c49b7b2f532.png)  | ![image](https://user-images.githubusercontent.com/8394463/183669174-6b712296-0025-4e42-ae77-df544f06a105.png) |

# 🗂 Related cards

[[Formula Fields/Async] Define, implement and document logs](https://app.pipefy.com/open-cards/557487967)
