### PR TITLE
refact: Make pipefy_message logs more Logfy-friendly

### DIFF
--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -68,7 +68,7 @@ module PipefyMessage
       def process_message
         obj = new
 
-        logger.info({ message_text: "Calling consumer poller" })
+        logger.info({ log_text: "Calling consumer poller" })
 
         build_consumer_instance.poller do |payload, metadata|
           start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
@@ -78,7 +78,7 @@ module PipefyMessage
           event_id = metadata[:eventId]
 
           logger.info(log_context({
-                                    message_text: "Message received by poller to be processed by consumer",
+                                    log_text: "Message received by poller to be processed by consumer",
                                     received_message: payload,
                                     metadata: metadata
                                   }, context, correlation_id, event_id))
@@ -90,7 +90,7 @@ module PipefyMessage
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start
           logger.info(log_context({
                                     duration_ms: elapsed_time_ms,
-                                    message_text: "Message received by consumer poller, processed " \
+                                    log_text: "Message received by consumer poller, processed " \
                                                   "in #{elapsed_time_ms} milliseconds"
                                   }, context, correlation_id, event_id))
         end
@@ -101,7 +101,7 @@ module PipefyMessage
         # this shows up in multiple places; OK or DRY up?
 
         logger.error(log_context({
-                                   message_text: "Failed to process message; details: #{e.inspect}"
+                                   log_text: "Failed to process message; details: #{e.inspect}"
                                  }, context, correlation_id, event_id))
         raise e
       end

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -91,7 +91,7 @@ module PipefyMessage
           logger.info(log_context({
                                     duration_ms: elapsed_time_ms,
                                     log_text: "Message received by consumer poller, processed " \
-                                                  "in #{elapsed_time_ms} milliseconds"
+                                              "in #{elapsed_time_ms} milliseconds"
                                   }, context, correlation_id, event_id))
         end
       rescue PipefyMessage::Providers::Errors::ResourceError => e

--- a/lib/pipefy_message/logging.rb
+++ b/lib/pipefy_message/logging.rb
@@ -35,8 +35,7 @@ module PipefyMessage
           { date: datetime.to_s,
             level: severity.to_s,
             app: progname.to_s,
-            context: "async_processing",
-            message: msg }.to_json + $INPUT_RECORD_SEPARATOR
+            context: "async_processing" }.merge(msg).to_json + $INPUT_RECORD_SEPARATOR
         end
       end
     end

--- a/lib/pipefy_message/logging.rb
+++ b/lib/pipefy_message/logging.rb
@@ -32,10 +32,11 @@ module PipefyMessage
         logger.level = LOG_LEVELS.index(ENV.fetch("ASYNC_LOG_LEVEL", "INFO")) || Logger::ERROR
 
         logger.formatter = proc do |severity, datetime, progname, msg|
-          { date: datetime.to_s,
+          { time: datetime.to_s,
             level: severity.to_s,
-            app: progname.to_s,
-            context: "async_processing" }.merge(msg).to_json + $INPUT_RECORD_SEPARATOR
+            program_name: progname.to_s,
+            context: "async_processing",
+            data: msg }.to_json + $INPUT_RECORD_SEPARATOR
         end
       end
     end

--- a/lib/pipefy_message/providers/aws_client/aws_client.rb
+++ b/lib/pipefy_message/providers/aws_client/aws_client.rb
@@ -14,7 +14,7 @@ module PipefyMessage
       ##
       # Sets up AWS options the first time an AWS service is used.
       def self.aws_setup
-        logger.info({ message_text: "AWS configurations set" })
+        logger.info({ log_text: "AWS configurations set" })
         Aws.config.update(retrieve_config)
       end
 

--- a/lib/pipefy_message/providers/aws_client/sns_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sns_broker.rb
@@ -17,7 +17,7 @@ module PipefyMessage
           AwsClient.aws_setup
 
           @sns = Aws::SNS::Resource.new
-          logger.debug({ message_text: "SNS resource created" })
+          logger.debug({ log_text: "SNS resource created" })
 
           @topic_arn_prefix = ENV.fetch("AWS_SNS_ARN_PREFIX", "arn:aws:sns:us-east-1:000000000000:")
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
@@ -37,7 +37,7 @@ module PipefyMessage
                         {
                           topic_arn: topic_arn,
                           payload: payload,
-                          message_text: "Attempting to publish a json message to topic #{topic_arn}"
+                          log_text: "Attempting to publish a json message to topic #{topic_arn}"
                         },
                         context, correlation_id, event_id
                       ))
@@ -63,7 +63,7 @@ module PipefyMessage
                         {
                           topic_arn: topic_arn,
                           message_id: result.message_id,
-                          message_text: "Message published"
+                          log_text: "Message published"
                         },
                         context, correlation_id, event_id
                       ))
@@ -78,7 +78,7 @@ module PipefyMessage
           logger.error(log_context(
                          {
                            topic_arn: topic_arn,
-                           message_text: "Failed to publish message",
+                           log_text: "Failed to publish message",
                            error_details: e.inspect
                          },
                          context, correlation_id, event_id

--- a/lib/pipefy_message/providers/aws_client/sns_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sns_broker.rb
@@ -21,7 +21,7 @@ module PipefyMessage
 
           @topic_arn_prefix = ENV.fetch("AWS_SNS_ARN_PREFIX", "arn:aws:sns:us-east-1:000000000000:")
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
-        rescue StandardError
+        rescue StandardError => e
           raise PipefyMessage::Providers::Errors::ResourceError, e.message
         end
 

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -27,7 +27,7 @@ module PipefyMessage
 
           logger.debug({
                          queue_url: @queue_url,
-                         message_text: "SQS client created"
+                         log_text: "SQS client created"
                        })
         rescue StandardError => e
           raise PipefyMessage::Providers::Errors::ResourceError, e.message
@@ -38,7 +38,7 @@ module PipefyMessage
         # in the initial configuration.
         def poller
           logger.info(merge_log_hash({
-                                       message_text: "Initiating SQS polling on queue #{@queue_url}"
+                                       log_text: "Initiating SQS polling on queue #{@queue_url}"
                                      }))
 
           @poller.poll({ wait_time_seconds: @config[:wait_time_seconds],
@@ -57,7 +57,7 @@ module PipefyMessage
 
             logger.debug(
               merge_log_hash(log_context({
-                                           message_text: "Message received by SQS poller"
+                                           log_text: "Message received by SQS poller"
                                          }, context, correlation_id, event_id))
             )
 
@@ -73,7 +73,7 @@ module PipefyMessage
             logger.error(
               merge_log_hash(log_context({
                                            queue_url: @queue_url,
-                                           message_text: "Failed to consume message; details: #{e.inspect}"
+                                           log_text: "Failed to consume message; details: #{e.inspect}"
                                          }, context, correlation_id, event_id))
             )
 

--- a/lib/pipefy_message/providers/broker_resolver.rb
+++ b/lib/pipefy_message/providers/broker_resolver.rb
@@ -23,7 +23,7 @@ module PipefyMessage
 
         logger.info({
                       broker: broker,
-                      message_text: "Resolved instance of #{broker} #{type}"
+                      log_text: "Resolved instance of #{broker} #{type}"
                     })
 
         map

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -6,13 +6,13 @@ end
 
 # Tbh, I dunno how to make these "real" tests; this is essentially
 # a makefile for automating manually checked tests atm :P But it's
-# better than nothing nor now.
+# better than nothing for now.
 RSpec.describe LoggerTester do
   it "is available as an instance method" do
-    subject.logger.error("Instance logger error")
+    subject.logger.error({ log_text: "Instance logger error" })
   end
 
   it "is available as a class method" do
-    described_class.logger.info("Class logger info")
+    described_class.logger.info({ log_text: "Class logger info" })
   end
 end


### PR DESCRIPTION
# Changes

This MR ~~removes the nesting of logs under a `message` field~~ renames the `message` log field to `data` to address an inconsistency with the `pipefy-core` logs that led to some issues with Logfy ([see Slack thread](https://pipefy.slack.com/archives/C02UMJDCFQQ/p1660058602160039)).

(Note: the previous strategy of removing nesting altogether has been altered after an alignment with the Logfy team, as they explained that having all fields that require indexing under a single key actually makes it easier to index them in Elasticsearch, at least until we have a globally defined standard for logs.)

The human-readable `message_text` field in logs has also been renamed to `log_text`, to avoid confusion with both the async messages and the Logfy `message` field. A small issue in `lib/pipefy_message/providers/aws_client/sns_broker.rb` that was identified in our async dojo has also been fixed.

Previously, the logs would look something like this:

`{"date":"2022-08-10 15:29:18 -0300","level":"INFO","app":"","context":"async_processing","message":{"context":"NO_CONTEXT_PROVIDED","correlation_id":"NO_CID_PROVIDED","event_id":"d094f8e7-b7cb-41c9-94be-549f25a75148","duration_ms":0,"message_text":"Message received by consumer poller, processed in 0 milliseconds"}}
`

Now, their format is:

`{"date":"2022-08-10 15:29:18 -0300","level":"INFO","app":"","context":"async_processing","data":{"context":"NO_CONTEXT_PROVIDED","correlation_id":"NO_CID_PROVIDED","event_id":"d094f8e7-b7cb-41c9-94be-549f25a75148","duration_ms":0,"log_text":"Message received by consumer poller, processed in 0 milliseconds"}}
`

# :repeat: Steps to reproduce

Simply following the README steps for using the gem locally is enough. Check that the logs being displayed match the second format given above.

# 🗂 Related cards

[[Formula Fields/Async] Define, implement and document logs](https://app.pipefy.com/open-cards/557487967)
