### PR TITLE
Proper handling of message according to Raw Message Delivery setting on AWS SNS/SQS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   localstack:
     container_name: localstack
-    image: localstack/localstack-light:0.14.3
+    image: localstack/localstack-light:1.0.4
     environment:
       AWS_DEFAULT_REGION: us-east-1
       LOCALSTACK_SERVICES: sns,sqs

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -84,7 +84,7 @@ module PipefyMessage
                                   }, context, correlation_id, event_id))
 
           retry_count = metadata["ApproximateReceiveCount"].to_i - 1
-          obj.perform(payload["Message"],
+          obj.perform(payload,
                       { retry_count: retry_count, context: context, correlation_id: correlation_id })
 
           elapsed_time_ms = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) - start

--- a/lib/pipefy_message/providers/aws_client/sns_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sns_broker.rb
@@ -21,7 +21,7 @@ module PipefyMessage
 
           @topic_arn_prefix = ENV.fetch("AWS_SNS_ARN_PREFIX", "arn:aws:sns:us-east-1:000000000000:")
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
-        rescue StandardError
+        rescue StandardError => e
           raise PipefyMessage::Providers::Errors::ResourceError, e.message
         end
 

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -43,10 +43,7 @@ module PipefyMessage
 
           @poller.poll({ wait_time_seconds: @config[:wait_time_seconds],
                          message_attribute_names: ["All"], attribute_names: ["All"] }) do |received_message|
-            payload = JSON.parse(received_message.body)
-            original_metadata = received_message.message_attributes.merge(received_message.attributes)
-
-            metadata = transform_metadata(original_metadata, payload)
+            metadata, payload = extract_metadata_and_payload(received_message)
             context = metadata[:context]
             correlation_id = metadata[:correlationId]
             event_id = metadata[:eventId]
@@ -60,7 +57,6 @@ module PipefyMessage
                                            message_text: "Message received by SQS poller"
                                          }, context, correlation_id, event_id))
             )
-
             yield(payload, metadata)
           rescue StandardError => e
             # error in the routine, skip delete to try the message again later with 30sec of delay
@@ -120,25 +116,30 @@ module PipefyMessage
                                   end
                                 end
 
-          if value_from_metadata.nil?
-            body_message_attribute_field.dig(key, "Value")
-          else
-            value_from_metadata
-          end
+          value_from_metadata.nil? ? body_message_attribute_field.dig(key, "Value") : value_from_metadata
         end
 
         ##
-        # Transform metadata to a simple hash
-        def transform_metadata(metadata, payload)
-          body_message_attribute_field_normalized = payload["MessageAttributes"] || {}
-          context = extract_metadata_value(metadata, "context", body_message_attribute_field_normalized)
-          correlation_id = extract_metadata_value(metadata, "correlationId", body_message_attribute_field_normalized)
-          event_id = extract_metadata_value(metadata, "eventId", body_message_attribute_field_normalized)
-          {
-            context: context,
-            correlationId: correlation_id,
-            eventId: event_id
-          }
+        # Transform metadata and payload to a simple hash
+        # Also handle differences if `Enable raw message delivery` SQS setting is on/off
+        def extract_metadata_and_payload(received_message)
+          original_metadata = received_message.message_attributes.merge(received_message.attributes)
+          body_as_json = JSON.parse(received_message.body)
+
+          body_message_attribute_field_normalized = body_as_json["MessageAttributes"] || {}
+          context = extract_metadata_value(original_metadata, "context", body_message_attribute_field_normalized)
+          correlation_id = extract_metadata_value(original_metadata, "correlationId", body_message_attribute_field_normalized)
+          event_id = extract_metadata_value(original_metadata, "eventId", body_message_attribute_field_normalized)
+          payload = body_as_json["Message"] || received_message.body
+
+          [
+            {
+              context: context,
+              correlationId: correlation_id,
+              eventId: event_id
+            },
+            payload
+          ]
         end
       end
     end

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -126,10 +126,10 @@ module PipefyMessage
           original_metadata = received_message.message_attributes.merge(received_message.attributes)
           body_as_json = JSON.parse(received_message.body)
 
-          body_message_attribute_field_normalized = body_as_json["MessageAttributes"] || {}
-          context = extract_metadata_value(original_metadata, "context", body_message_attribute_field_normalized)
-          correlation_id = extract_metadata_value(original_metadata, "correlationId", body_message_attribute_field_normalized)
-          event_id = extract_metadata_value(original_metadata, "eventId", body_message_attribute_field_normalized)
+          body_message_attribute = body_as_json["MessageAttributes"] || {}
+          context = extract_metadata_value(original_metadata, "context", body_message_attribute)
+          correlation_id = extract_metadata_value(original_metadata, "correlationId", body_message_attribute)
+          event_id = extract_metadata_value(original_metadata, "eventId", body_message_attribute)
           payload = body_as_json["Message"] || received_message.body
 
           [

--- a/spec/providers/aws/sqs_broker_spec.rb
+++ b/spec/providers/aws/sqs_broker_spec.rb
@@ -57,29 +57,66 @@ RSpec.describe PipefyMessage::Providers::AwsClient::SqsBroker do
   end
 
   describe "#poller" do
-    it "should consume a message" do
-      mocked_message = { message_id: "44c44782-fee1-6784-d614-43b73c0bda8d",
-                         receipt_handle: "2312dasdas1231221312321adsads",
-                         body: "{\"Message\": {\"foo\": \"bar\"}}" }
+    let(:expected_result) { { "default" => { "foo" => "bar" } }.to_json }
 
-      mocked_poller = Aws::SQS::QueuePoller.new("http://localhost:4566/000000000000/my_queue",
-                                                { skip_delete: true })
-      mocked_poller.before_request { |stats| throw :stop_polling if stats.received_message_count > 0 }
-
-      mocked_element = Aws::SQS::Types::Message.new(mocked_message)
-      mocked_list = Aws::Xml::DefaultList.new
-      mocked_list.append(mocked_element)
-      mocked_poller.client.stub_responses(:receive_message, messages: mocked_list)
-
-      worker = described_class.new
-      worker.instance_variable_set(:@poller, mocked_poller)
-
-      result = nil
-      expected_result = { "Message" => { "foo" => "bar" } }
-      worker.poller do |message|
-        result = message
+    context "Raw Message Delivery disabled" do
+      let(:mocked_message) do
+        {
+          message_id: "44c44782-fee1-6784-d614-43b73c0bda8d",
+          receipt_handle: "2312dasdas1231221312321adsads",
+          body: "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"6c7057f5-0d43-54ad-a502-0c9a4b6cdcf1\",\n  \"TopicArn\" : \"arn:aws:sns:us-east-1:038527119583:core-card-field-value-updated-topic\",\n  \"Message\" : \"{\\\"default\\\":{\\\"foo\\\":\\\"bar\\\"}}\",\n  \"Timestamp\" : \"2022-08-11T18:01:19.875Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"GrOeiHuqVV9eB+RAWZ2XYe2ko/KXxnxVhQ/sW8zV3ybgO0UD6BI32XL/mw4r562msXpG0BZc7dFbJG6XPVcQ7YZWnVKU7c34nS9NyTimMTz5Df/raKCdVkxigMhbS45CPMC//u7Sz9fDb/MXTrInnuSVPY14/QwEwXqyV45M+lTzLoBJSM05UX0eo1MOQxRQ8IYgPay5z6BSSHq4B6/59U88PMv4VJLNaWIb8dTiO1ixK9Nz7Xk/dqqC/bI6A+VLUNhVSitDfkDaPPoSG5qFnBPRzpcQhznANkjecW6MSWtCf0R8BuSqAYNxoCzDcC5xOf3zJOccfUTwvxz5f5jwfg==\",\n  \"SigningCertURL\" : \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem\",\n  \"UnsubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:038527119583:core-card-field-value-updated-topic:995474b4-3a57-4c94-abdf-3ba50244723d\",\n  \"MessageAttributes\" : {\n    \"eventId\" : {\"Type\":\"String\",\"Value\":\"30043493-d47d-4445-b5f6-17881df4b5f3\"},\n    \"context\" : {\"Type\":\"String\",\"Value\":\"NO_CONTEXT_PROVIDED\"},\n    \"correlationId\" : {\"Type\":\"String\",\"Value\":\"b41daa3fa2f0469eed7fc5b0534f0bc6\"}\n  }\n}"
+        }
       end
-      expect(result).to eq expected_result
+
+      it "should consume a message " do
+        mocked_poller = Aws::SQS::QueuePoller.new("http://localhost:4566/000000000000/my_queue",
+                                                  { skip_delete: true })
+        mocked_poller.before_request { |stats| throw :stop_polling if stats.received_message_count > 0 }
+
+        mocked_element = Aws::SQS::Types::Message.new(mocked_message)
+        mocked_list = Aws::Xml::DefaultList.new
+        mocked_list.append(mocked_element)
+        mocked_poller.client.stub_responses(:receive_message, messages: mocked_list)
+
+        worker = described_class.new
+        worker.instance_variable_set(:@poller, mocked_poller)
+
+        result = nil
+        worker.poller do |message|
+          result = message
+        end
+        expect(result).to eq expected_result
+      end
+    end
+
+    context "Raw Message Delivery enabled" do
+      let(:mocked_message) do
+        {
+          message_id: "44c44782-fee1-6784-d614-43b73c0bda8d",
+          receipt_handle: "2312dasdas1231221312321adsads",
+          body: "{\"default\":{\"foo\":\"bar\"}}"
+        }
+      end
+
+      it "should consume a message " do
+        mocked_poller = Aws::SQS::QueuePoller.new("http://localhost:4566/000000000000/my_queue",
+                                                  { skip_delete: true })
+        mocked_poller.before_request { |stats| throw :stop_polling if stats.received_message_count > 0 }
+
+        mocked_element = Aws::SQS::Types::Message.new(mocked_message)
+        mocked_list = Aws::Xml::DefaultList.new
+        mocked_list.append(mocked_element)
+        mocked_poller.client.stub_responses(:receive_message, messages: mocked_list)
+
+        worker = described_class.new
+        worker.instance_variable_set(:@poller, mocked_poller)
+
+        result = nil
+        worker.poller do |message|
+          result = message
+        end
+        expect(result).to eq expected_result
+      end
     end
   end
 

--- a/spec/providers/aws/sqs_broker_spec.rb
+++ b/spec/providers/aws/sqs_broker_spec.rb
@@ -60,11 +60,33 @@ RSpec.describe PipefyMessage::Providers::AwsClient::SqsBroker do
     let(:expected_result) { { "default" => { "foo" => "bar" } }.to_json }
 
     context "Raw Message Delivery disabled" do
+      let(:body_json) do
+        # rubocop:disable Layout/HeredocIndentation
+        <<~EOS_BODY
+        {
+          \"Type\" : \"Notification\",
+          \"MessageId\" : \"6c7057f5-0d43-54ad-a502-0c9a4b6cdcf1\",
+          \"TopicArn\" : \"arn:aws:sns:us-east-1:038527119583:core-card-field-value-updated-topic\",
+          \"Message\" : \"{\\\"default\\\":{\\\"foo\\\":\\\"bar\\\"}}\",
+          \"Timestamp\" : \"2022-08-11T18:01:19.875Z\",
+          \"SignatureVersion\" : \"1\",
+          \"Signature\" : \"GrOeiHuqVV9eB+RAWZ2XYe2ko/KXxnxVhQ/sW8zV3ybgO0UD6BI32XL/mw4r562msXpG0BZc7dFbJG6XPVcQ7YZWnVKU7c34nS9NyTimMTz5Df/raKCdVkxigMhbS45CPMC//u7Sz9fDb/MXTrInnuSVPY14/QwEwXqyV45M+lTzLoBJSM05UX0eo1MOQxRQ8IYgPay5z6BSSHq4B6/59U88PMv4VJLNaWIb8dTiO1ixK9Nz7Xk/dqqC/bI6A+VLUNhVSitDfkDaPPoSG5qFnBPRzpcQhznANkjecW6MSWtCf0R8BuSqAYNxoCzDcC5xOf3zJOccfUTwvxz5f5jwfg==\",
+          \"SigningCertURL\" : \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem\",
+          \"UnsubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:038527119583:core-card-field-value-updated-topic:995474b4-3a57-4c94-abdf-3ba50244723d\",
+          \"MessageAttributes\" : {
+            \"eventId\" : {\"Type\":\"String\",\"Value\":\"30043493-d47d-4445-b5f6-17881df4b5f3\"},
+            \"context\" : {\"Type\":\"String\",\"Value\":\"NO_CONTEXT_PROVIDED\"},
+            \"correlationId\" : {\"Type\":\"String\",\"Value\":\"b41daa3fa2f0469eed7fc5b0534f0bc6\"}
+          }
+        }
+        EOS_BODY
+        # rubocop:enable Layout/HeredocIndentation
+      end
       let(:mocked_message) do
         {
           message_id: "44c44782-fee1-6784-d614-43b73c0bda8d",
           receipt_handle: "2312dasdas1231221312321adsads",
-          body: "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"6c7057f5-0d43-54ad-a502-0c9a4b6cdcf1\",\n  \"TopicArn\" : \"arn:aws:sns:us-east-1:038527119583:core-card-field-value-updated-topic\",\n  \"Message\" : \"{\\\"default\\\":{\\\"foo\\\":\\\"bar\\\"}}\",\n  \"Timestamp\" : \"2022-08-11T18:01:19.875Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"GrOeiHuqVV9eB+RAWZ2XYe2ko/KXxnxVhQ/sW8zV3ybgO0UD6BI32XL/mw4r562msXpG0BZc7dFbJG6XPVcQ7YZWnVKU7c34nS9NyTimMTz5Df/raKCdVkxigMhbS45CPMC//u7Sz9fDb/MXTrInnuSVPY14/QwEwXqyV45M+lTzLoBJSM05UX0eo1MOQxRQ8IYgPay5z6BSSHq4B6/59U88PMv4VJLNaWIb8dTiO1ixK9Nz7Xk/dqqC/bI6A+VLUNhVSitDfkDaPPoSG5qFnBPRzpcQhznANkjecW6MSWtCf0R8BuSqAYNxoCzDcC5xOf3zJOccfUTwvxz5f5jwfg==\",\n  \"SigningCertURL\" : \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-56e67fcb41f6fec09b0196692625d385.pem\",\n  \"UnsubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:038527119583:core-card-field-value-updated-topic:995474b4-3a57-4c94-abdf-3ba50244723d\",\n  \"MessageAttributes\" : {\n    \"eventId\" : {\"Type\":\"String\",\"Value\":\"30043493-d47d-4445-b5f6-17881df4b5f3\"},\n    \"context\" : {\"Type\":\"String\",\"Value\":\"NO_CONTEXT_PROVIDED\"},\n    \"correlationId\" : {\"Type\":\"String\",\"Value\":\"b41daa3fa2f0469eed7fc5b0534f0bc6\"}\n  }\n}"
+          body: body_json
         }
       end
 


### PR DESCRIPTION
# ✨ New Feature

Message attributes cam come in 2 places: inside body payload or in a specific attribute (`message_attribute`), according to its SNS configuration on AWS.

According to `Raw Message Delivery` setting on AWS SNS/SQS, the content of delivered message changes. This MR aims to handle both case.

There was a difference between `localstack` and `aws` regard handling `message_attribute`. Upgrading `localstack` docker image fixed this issue and now both of them brings `message_attributes` only inside `body`.

# :repeat: Steps to reproduce

Enable/disable this feature for a SQS subscribed in a SNS: `Raw message delivery`

![image](https://user-images.githubusercontent.com/8394463/184021459-22be5f26-60e7-475a-8256-057377dcf7ce.png)

When disabled (default option), it has the following structure:

![image](https://user-images.githubusercontent.com/8394463/184199735-8fdbf643-3f0a-47fa-a4c7-1c80f3f9f0d7.png)

When enabled, it has the following structure

![image](https://user-images.githubusercontent.com/8394463/184199980-bc6b20f4-ab1d-4189-94e9-e3971d04752e.png)

# 🖼 Screenshots

| Before 🐛 | After ✨ |
| --------- | -------- |
|           |          |

# 🗂 Related cards

[[Formula Field] Handle difference according SNS setting `Enable raw message delivery`](https://app.pipefy.com/open-cards/564400066)
