### PR TITLE
Improvement: Make error logs more granular and detailed

### DIFF
--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -4,6 +4,7 @@
 require "rubygems"
 require "singleton"
 require "thor"
+require "pipefy_message"
 
 module PipefyMessage
   # CLI
@@ -24,6 +25,8 @@ module PipefyMessage
   # Runner
   class Runner
     include Singleton
+    include PipefyMessage::Logging
+
     def initialize_rails
       # Adapted from: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb
 
@@ -35,6 +38,9 @@ module PipefyMessage
         require File.expand_path("config/application.rb")
         require File.expand_path("config/environment.rb")
       end
+
+      # Override rails logger by gem logger
+      ::Rails.logger = logger
     end
 
     def write_pid(options)

--- a/bin/pipefymessage
+++ b/bin/pipefymessage
@@ -4,7 +4,6 @@
 require "rubygems"
 require "singleton"
 require "thor"
-require "pipefy_message"
 
 module PipefyMessage
   # CLI
@@ -25,8 +24,6 @@ module PipefyMessage
   # Runner
   class Runner
     include Singleton
-    include PipefyMessage::Logging
-
     def initialize_rails
       # Adapted from: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb
 
@@ -38,9 +35,6 @@ module PipefyMessage
         require File.expand_path("config/application.rb")
         require File.expand_path("config/environment.rb")
       end
-
-      # Override rails logger by gem logger
-      ::Rails.logger = logger
     end
 
     def write_pid(options)

--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -92,7 +92,7 @@ module PipefyMessage
             logger.error(log_context({
                                        received_message: payload,
                                        received_metadata: metadata,
-                                       log_text: "Consumer #{obj.name}.perform method failed to process "\
+                                       log_text: "Consumer #{obj.class.name}.perform method failed to process "\
                                                  "received_message with #{e.inspect}"
                                      }, context, correlation_id, event_id))
             raise e

--- a/lib/pipefy_message/logging.rb
+++ b/lib/pipefy_message/logging.rb
@@ -32,11 +32,12 @@ module PipefyMessage
         logger.level = LOG_LEVELS.index(ENV.fetch("ASYNC_LOG_LEVEL", "INFO")) || Logger::ERROR
 
         logger.formatter = proc do |severity, datetime, progname, msg|
+          msg_hash = msg.is_a?(Hash) ? msg : { log_text: msg }
           { time: datetime.to_s,
             level: severity.to_s,
             program_name: progname.to_s,
             context: "async_processing",
-            data: msg }.to_json + $INPUT_RECORD_SEPARATOR
+            data: msg_hash }.to_json + $INPUT_RECORD_SEPARATOR
         end
       end
     end

--- a/lib/pipefy_message/providers/aws_client/sqs_broker.rb
+++ b/lib/pipefy_message/providers/aws_client/sqs_broker.rb
@@ -17,17 +17,12 @@ module PipefyMessage
           AwsClient.aws_setup
 
           @sqs = Aws::SQS::Client.new
-
           @is_staging = ENV["ASYNC_APP_ENV"] == "staging"
-
           @queue_url = handle_queue_protocol(@sqs.get_queue_url({ queue_name: handle_queue_name(@config[:queue_name]) })
                                                  .queue_url)
-
           @poller = Aws::SQS::QueuePoller.new(@queue_url, { client: @sqs })
 
-          logger.debug(log_queue_info({
-                                        log_text: "SQS client created"
-                                      }))
+          logger.debug(log_queue_info({ log_text: "SQS client created" }))
         rescue Aws::SQS::Errors::QueueDoesNotExist, Aws::SQS::Errors::NonExistentQueue
           logger.error({
                          queue_name: @config[:queue_name],
@@ -39,12 +34,10 @@ module PipefyMessage
                 "The specified AWS SQS queue #{@config[:queue_name]} does not exist"
         rescue StandardError => e
           msg = "Failed to initialize AWS SQS broker with #{e.inspect}"
-
           logger.error({
                          queue_name: @config[:queue_name],
                          log_text: msg
                        })
-
           raise PipefyMessage::Providers::Errors::ResourceError, msg
         end
 
@@ -52,9 +45,7 @@ module PipefyMessage
         # Initiates SQS queue polling, with wait_time_seconds as given
         # in the initial configuration.
         def poller
-          logger.info(log_queue_info({
-                                       log_text: "Initiating SQS polling on queue #{@queue_url}"
-                                     }))
+          logger.info(log_queue_info({ log_text: "Initiating SQS polling on queue #{@queue_url}" }))
 
           @poller.poll({ wait_time_seconds: @config[:wait_time_seconds],
                          message_attribute_names: ["All"], attribute_names: ["All"] }) do |received_message|
@@ -79,7 +70,6 @@ module PipefyMessage
               # This would probably only be the case if a malformed and
               # thus unparseable message is received (eg: in case of
               # breaking changes in SQS)
-
               logger.error(log_queue_info({
                                             received_message: received_message,
                                             log_text: "Consuming received_message failed with #{e.inspect}"
@@ -91,7 +81,6 @@ module PipefyMessage
             end
 
             # error in the routine, skip delete to try the message again later with 30sec of delay
-
             throw e if e.instance_of?(NameError)
 
             throw :skip_delete

--- a/lib/pipefy_message/providers/errors.rb
+++ b/lib/pipefy_message/providers/errors.rb
@@ -8,53 +8,23 @@ module PipefyMessage
     # as common error messages.
     module Errors
       ##
-      # Enables automatic error logging when prepended to a custom error
-      # class.
-      #
-      # In order for this module to work, the prepending class must
-      # inherit from the Ruby Exception class. Note that this condition
-      # is satisfied by any custom error class that inherits from
-      # StandardError and its children, such as RuntimeError, given that
-      # StandardError is itself a child of Exception.
-      #
-      # The reason to use prepend rather than include is to make this
-      # module come below the error class in the inheritance chain.
-      # This ensures that, when an error is raised and its constructor
-      # is called, this module's initialize method gets called first,
-      # then calls the original constructor with super, and calls the
-      # logger once initialization is done. This effectively "wraps"
-      # the error initialize method in the logging constructor below.
-      module LoggingError
-        prepend PipefyMessage::Logging
+      # Abstraction for service and networking errors.
+      class ResourceError < RuntimeError
+      end
 
-        def initialize(msg = nil)
+      ##
+      # Abstraction for errors caused by nonexisting queues, such as
+      # Aws::SQS::Errors::QueueDoesNotExist.
+      class QueueDoesNotExist < ResourceError
+        def initialize(msg = "The specified queue does not exist")
           super
-          logger.error({
-                         error_class: self.class,
-                         error_message: message,
-                         stack_trace: full_message
-                       })
-
-          # message and full_message are methods provided by the
-          # Ruby Exception class.
-          # The hash keys used above were an attempt to provide more
-          # descriptive names than those of the original methods (:P),
-          # but this has still led to some confusion, so, to be more
-          # explicit: if e is an instance of Exception (or its
-          # children), e.message returns the error message for e and
-          # e.full_message provides the full stack trace. This is
-          # what's being included in the logs above. Logging inside
-          # the constructor ensures information is logged as soon
-          # as the error is raised.
-          # For details, please refer to the official documentation for
-          # the Exception class.
         end
       end
 
       ##
-      # Abstraction for service and networking errors.
-      class ResourceError < RuntimeError
-        prepend PipefyMessage::Providers::Errors::LoggingError
+      # Abstraction for provider authorization errors, such as
+      # Aws::SNS::Errors::AuthorizationError.
+      class AuthorizationError < RuntimeError
       end
 
       ##
@@ -62,7 +32,6 @@ module PipefyMessage
       # to a method call (eg: if a queueing service client is
       # initialized with an invalid queue identifier).
       class InvalidOption < ArgumentError
-        prepend PipefyMessage::Providers::Errors::LoggingError
       end
 
       # Error messages:


### PR DESCRIPTION
# Improvement

During our tests, we realized the error logs we currently have on `pipefy_message` don't contain enough information to help diagnose what's causing something to fail. This MR attempts to remedy this issue by adding more information to various error logs as well as by making them more granular, by `rescue`ing errors in different steps separately.

A new error class, `QueueDoesNotExist` (which inherits from our custom `ResourceError`), has also been introduced, as that was a very common resource error when going over our current logs.

Moreover, automatic logging on custom exception instantiation has been disabled, as that generated a separate log that was hard to find later on and thus had very limited use.

# 🗂 Related cards

[Improve error logs on pipefy_message gem](https://app.pipefy.com/open-cards/564399102)
