### PR TITLE
:loud_sound: Force flushing logs after processing a message

### DIFF
--- a/lib/pipefy_message/consumer.rb
+++ b/lib/pipefy_message/consumer.rb
@@ -104,6 +104,7 @@ module PipefyMessage
                                     log_text: "Message received by consumer poller, processed " \
                                               "in #{elapsed_time_ms} milliseconds"
                                   }, context, correlation_id, event_id))
+          $stdout.flush # Ensure everything is flushed to log after processing a message
         end
       rescue StandardError => e
         context = "NO_CONTEXT_RETRIEVED" unless defined? context


### PR DESCRIPTION
# ✨ New Feature

Try not to retain logs on buffer after processing a message.

# :repeat: Steps to reproduce

Do a operation that doesn't generate many lines of logs, like, creating a new formula field.

# 🖼 Screenshots

N/A

# 🗂 Related cards

[[Formula Fields] What happens when a pod is killed during a formula field calculation](https://app.pipefy.com/open-cards/567096375)
